### PR TITLE
docs: add feature plans and phased roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,19 @@ Required variables (see turbo.json for full list):
 - `STACK_SECRET_SERVER_KEY` - Stack Auth server key
 - `CRON_SECRET` - Secret for cron job endpoints
 
+## Roadmap & Feature Plans
+
+The full roadmap is at [`docs/TODO.md`](docs/TODO.md). Each planned feature has a detailed plan in [`docs/features/`](docs/features/) covering:
+- Functionality description, Prisma schema additions, components, pages, API endpoints, Zod schemas, permissions, and dependencies.
+
+Features are organized in four phases:
+1. **Phase 1** — Admin Infrastructure, Role/Permission Management, Audit Log
+2. **Phase 2** — User Management, Member Management, Member Corner
+3. **Phase 3** — Sermon Admin, Announcements, Events, Content CMS
+4. **Phase 4** — Bible Lookup (enhanced), PPT Generation, Live Translation
+
+When implementing a feature, always read its plan in `docs/features/` first and follow the patterns described there.
+
 ## Deployment
 
 - Hosted on Vercel

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,13 +1,102 @@
-Admin Portal
+# SCCNY Roadmap
 
-- [] Member Corner
+This document tracks all planned features for the SCCNY web application. Each item links to a detailed feature plan in [`docs/features/`](./features/).
 
-Tool Portal
+## Legend
 
-- [] Live Translation
-- [] Bible Look up
-- [] PPT Generation
+| Symbol | Meaning |
+|--------|---------|
+| :white_check_mark: | Completed |
+| :construction: | In Progress |
+| :clipboard: | Planned (has feature plan) |
 
-Infrastructure
+---
 
-- [] Switch to PNPM
+## Phase 0: Infrastructure
+
+| Status | Feature | Plan |
+|--------|---------|------|
+| :white_check_mark: | Switch to PNPM | — |
+| :white_check_mark: | Sermon API + Scraper | [sermon-api-implementation.md](./features/sermon-api-implementation.md) |
+| :white_check_mark: | News API + Scraper | [news-implementation.md](./features/news-implementation.md) |
+| :white_check_mark: | Message Pages (Sermon Recordings, Sunday School, etc.) | [message-pages-implementation.md](./features/message-pages-implementation.md) |
+
+## Phase 1: Auth Foundation & Admin Shell
+
+These are prerequisites for all admin features. Build first.
+
+| Status | Feature | Plan | Dependencies |
+|--------|---------|------|--------------|
+| :clipboard: | Admin Portal Infrastructure | [admin-infrastructure.md](./features/admin-infrastructure.md) | — |
+| :clipboard: | Role Management | [role-management.md](./features/role-management.md) | Admin Infrastructure |
+| :clipboard: | Permission Management | [permission-management.md](./features/permission-management.md) | Role Management |
+| :clipboard: | Audit Log | [audit-log.md](./features/audit-log.md) | Admin Infrastructure |
+
+## Phase 2: User & Member System
+
+User accounts and church member data.
+
+| Status | Feature | Plan | Dependencies |
+|--------|---------|------|--------------|
+| :clipboard: | User Management | [user-management.md](./features/user-management.md) | Phase 1 |
+| :clipboard: | Member Management | [member-management.md](./features/member-management.md) | Phase 1, User Management |
+| :clipboard: | Member Corner | [member-corner.md](./features/member-corner.md) | Member Management |
+
+## Phase 3: Content & Sermon Admin
+
+Admin CRUD for existing and new content types.
+
+| Status | Feature | Plan | Dependencies |
+|--------|---------|------|--------------|
+| :clipboard: | Sermon Management (Admin) | [sermon-management.md](./features/sermon-management.md) | Phase 1 |
+| :clipboard: | Announcement Management | [announcement-management.md](./features/announcement-management.md) | Phase 1 |
+| :clipboard: | Event Management | [event-management.md](./features/event-management.md) | Phase 1 |
+| :clipboard: | Content Management (CMS) | [content-management.md](./features/content-management.md) | Phase 1 |
+
+## Phase 4: Tool Portal
+
+Standalone tools for ministry support.
+
+| Status | Feature | Plan | Dependencies |
+|--------|---------|------|--------------|
+| :clipboard: | Bible Lookup (Enhanced) | [bible-lookup.md](./features/bible-lookup.md) | — |
+| :clipboard: | PPT Generation | [ppt-generation.md](./features/ppt-generation.md) | Bible Lookup (for scripture items) |
+| :clipboard: | Live Translation | [live-translation.md](./features/live-translation.md) | Admin Infrastructure (for operator auth) |
+
+---
+
+## Prisma Schema Overview
+
+New models required across all features (cumulative):
+
+| Model | Introduced In |
+|-------|---------------|
+| `Role` | Role Management |
+| `Permission` | Permission Management |
+| `RolePermission` | Permission Management |
+| `UserRole` | Role Management |
+| `AuditLog` | Audit Log |
+| `Member` | Member Corner |
+| `PrayerRequest` | Member Corner |
+| `Event` | Event Management |
+| `EventRegistration` | Event Management |
+| `Announcement` | Announcement Management |
+| `ContentPage` | Content Management |
+| `ContentRevision` | Content Management |
+| `MediaAsset` | Content Management |
+| `TranslationSession` | Live Translation |
+| `TranslationEntry` | Live Translation |
+| `Hymn` | PPT Generation |
+| `PptTemplate` | PPT Generation |
+| `WorshipOrder` | PPT Generation |
+| `WorshipOrderItem` | PPT Generation |
+| `BibleVerse` | Bible Lookup (if local DB approach) |
+
+## New Package Dependencies
+
+| Package | Used By |
+|---------|---------|
+| `@tiptap/react` + `@tiptap/starter-kit` | Content Management (rich text editor) |
+| `@vercel/blob` | Content Management (media upload) |
+| `pptxgenjs` | PPT Generation |
+| `@hello-pangea/dnd` | PPT Generation (drag-and-drop) |

--- a/docs/features/admin-infrastructure.md
+++ b/docs/features/admin-infrastructure.md
@@ -1,0 +1,87 @@
+# Admin Portal Infrastructure
+
+## Overview
+
+Shared foundation for all admin portal features. Establishes the admin layout shell, route protection, and common patterns that every admin module depends on.
+
+## Core Objectives
+
+- **Admin Layout**: Sidebar + top-bar shell for all admin pages
+- **Route Protection**: Auth-gated access using Stack Auth
+- **Admin Dashboard**: Summary landing page with key metrics
+- **Shared Patterns**: Reusable table, form, and filter components
+
+## Implementation Details
+
+### Admin Layout (`app/[locale]/admin/layout.tsx`)
+
+- Sidebar navigation with links to each admin section (Members, Sermons, News, Events, Announcements, Users, Roles, Audit Log)
+- Top bar with user avatar, logout button, and breadcrumb trail
+- Uses Stack Auth's `useUser()` to gate access; redirects unauthenticated users to Stack's sign-in page
+- Responsive: sidebar collapses to hamburger on mobile
+- Bilingual labels from `messages/*.json` under an `"Admin"` namespace
+
+### Middleware Update (`src/middleware.ts`)
+
+- Extend the existing next-intl middleware to intercept `/admin/*` routes
+- Check auth session via `stackServerApp.getUser()`
+- Redirect to Stack Auth login page if no valid session
+- After login, redirect back to the originally requested admin page
+
+### Admin Dashboard (`app/[locale]/admin/page.tsx`)
+
+- Summary cards showing counts: total members, sermons, news articles, events, users
+- Recent activity feed from the audit log (last 10 entries)
+- Quick-action buttons: "Add Sermon", "Create Event", "New Announcement"
+- Uses existing `dark-blue` components: Card, CardContent, CardTitle, Button
+
+### Shared Admin Components
+
+| Component | Purpose |
+|-----------|---------|
+| `AdminSidebar` | Navigation sidebar with section links and active state |
+| `AdminTopBar` | User info, logout, breadcrumbs |
+| `DataTable` | Reusable sortable/filterable table with pagination |
+| `FormDialog` | Modal dialog for create/edit forms |
+| `StatusBadge` | Colored badge for status fields (ACTIVE, DRAFT, etc.) |
+| `ConfirmDialog` | Destructive action confirmation modal |
+| `BulkActionBar` | Toolbar for multi-select operations |
+
+### API Route Group (`app/api/admin/`)
+
+- All admin endpoints live under `/api/admin/`
+- Each route handler calls `stackServerApp.getUser()` and checks permissions before processing
+- Shared error response format: `{ error: string, details?: unknown }`
+- Shared success format: `{ data, pagination? }`
+
+### i18n Keys
+
+Add `"Admin"` namespace to `en.json` / `zh.json` covering:
+- Sidebar labels, dashboard titles, common actions (Save, Cancel, Delete, Edit, Create)
+- Confirmation dialog messages
+- Table headers and empty-state messages
+
+## File Structure
+
+```
+src/
+├── app/[locale]/admin/
+│   ├── layout.tsx           # Admin shell layout
+│   └── page.tsx             # Dashboard
+├── components/admin/
+│   ├── AdminSidebar.tsx
+│   ├── AdminTopBar.tsx
+│   ├── DataTable.tsx
+│   ├── FormDialog.tsx
+│   ├── StatusBadge.tsx
+│   ├── ConfirmDialog.tsx
+│   └── BulkActionBar.tsx
+└── lib/
+    ├── admin-auth.ts        # Auth check helpers for API routes
+    └── admin-utils.ts       # Shared admin utilities
+```
+
+## Dependencies
+
+- Existing: `@stackframe/stack`, `dark-blue`, `next-intl`
+- No new npm packages required

--- a/docs/features/announcement-management.md
+++ b/docs/features/announcement-management.md
@@ -1,0 +1,134 @@
+# Announcement Management
+
+## Overview
+
+Manage church-wide announcements that appear on the home page, in the member corner, and optionally as targeted notices. Separate from the existing News model — announcements are time-boxed, priority-driven internal notices, while news is article-style public content.
+
+## Core Objectives
+
+- **Time-Boxed Display**: Announcements with start/end dates auto-appear and auto-expire
+- **Priority System**: Normal, Important, and Urgent levels with visual distinction
+- **Audience Targeting**: All visitors vs. members-only
+- **Pinning**: Pin important announcements to top of lists
+- **Bilingual**: Full en/zh content support
+
+## Functionality
+
+- Create/edit/delete announcements with bilingual content
+- Set priority level (NORMAL, IMPORTANT, URGENT)
+- Set audience (ALL, MEMBERS_ONLY)
+- Schedule display window (startDate — endDate)
+- Pin/unpin announcements
+- Rich text content with image support
+- Draft/Publish/Archive workflow
+- View on public site: home page banner for URGENT, announcement list for others
+
+## Prisma Schema Addition
+
+```prisma
+model Announcement {
+  id          String               @id @default(cuid())
+  titleEn     String
+  titleZh     String
+  contentEn   String               @db.Text
+  contentZh   String               @db.Text
+  priority    AnnouncementPriority @default(NORMAL)
+  audience    AnnouncementAudience @default(ALL)
+  startDate   DateTime
+  endDate     DateTime?
+  isPinned    Boolean              @default(false)
+  status      AnnouncementStatus   @default(DRAFT)
+  createdById String
+  createdAt   DateTime             @default(now())
+  updatedAt   DateTime             @updatedAt
+
+  @@map("announcements")
+}
+
+enum AnnouncementPriority {
+  NORMAL
+  IMPORTANT
+  URGENT
+}
+
+enum AnnouncementAudience {
+  ALL
+  MEMBERS_ONLY
+}
+
+enum AnnouncementStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+}
+```
+
+## Components
+
+### Admin Components
+| Component | Purpose |
+|-----------|---------|
+| `AnnouncementTable` | List with status/priority badges, date range filters |
+| `AnnouncementForm` | Create/edit with rich text, scheduling, priority/audience selectors |
+| `AnnouncementPreview` | Preview how the announcement will look on the public site |
+
+### Public Components
+| Component | Purpose |
+|-----------|---------|
+| `AnnouncementBanner` | Full-width banner for URGENT/pinned announcements on home page |
+| `AnnouncementList` | List of current announcements (used on home page and member corner) |
+| `AnnouncementCard` | Individual announcement card with priority styling |
+
+## Pages
+
+### Admin
+| Route | Description |
+|-------|-------------|
+| `app/[locale]/admin/announcements/page.tsx` | Announcement list/management |
+
+### Public
+Announcements display inline on existing pages (home page, member corner) — no dedicated public page needed.
+
+## API Endpoints
+
+### Admin
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/admin/announcements` | Paginated list with filters |
+| `POST` | `/api/admin/announcements` | Create announcement |
+| `GET` | `/api/admin/announcements/[id]` | Get announcement |
+| `PATCH` | `/api/admin/announcements/[id]` | Update announcement |
+| `DELETE` | `/api/admin/announcements/[id]` | Delete announcement |
+
+### Public
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/announcements` | Current published announcements (within date window) |
+
+## News vs. Announcements Distinction
+
+| Aspect | News | Announcements |
+|--------|------|---------------|
+| Content type | Article-style, long-form | Short notice, bulletin-style |
+| Lifespan | Permanent (archived, never hidden) | Time-boxed (auto-expires) |
+| Priority | No priority system | NORMAL / IMPORTANT / URGENT |
+| Audience | Always public | Public or members-only |
+| Display | Dedicated news page | Banner, sidebar, member corner |
+| Source | Scraped from legacy site + manual | Always manual |
+
+## i18n Keys
+
+Add `"Announcements"` namespace for admin and public labels.
+
+## Permissions Required
+
+- `announcements.view` — view announcement list
+- `announcements.create` — create announcements
+- `announcements.edit` — edit announcements
+- `announcements.delete` — delete announcements
+
+## Dependencies
+
+- Requires: Admin Infrastructure, Permission system
+- Existing: `dark-blue`, `zod`, `date-fns`
+- No new npm packages

--- a/docs/features/audit-log.md
+++ b/docs/features/audit-log.md
@@ -1,0 +1,128 @@
+# Audit Log
+
+## Overview
+
+Track all admin actions for accountability and debugging. Every create, update, and delete operation in the admin portal is recorded with who did it, when, and what changed.
+
+## Core Objectives
+
+- **Automatic Logging**: All admin mutations are logged without manual intervention
+- **Change Tracking**: Store old and new values for update operations
+- **Searchable History**: Filter logs by user, action, resource, date range
+- **Exportable**: Download logs as CSV for compliance or review
+- **Retention**: Configurable auto-purge for old entries
+
+## Prisma Schema Addition
+
+```prisma
+model AuditLog {
+  id           String   @id @default(cuid())
+  userId       String   // Stack Auth user ID
+  userName     String   // Denormalized for display
+  action       String   // CREATE, UPDATE, DELETE, LOGIN, EXPORT, SYNC
+  resourceType String   // e.g. "sermon", "member", "event"
+  resourceId   String?  // ID of the affected record
+  oldValues    Json?    // Previous state (for UPDATE/DELETE)
+  newValues    Json?    // New state (for CREATE/UPDATE)
+  ipAddress    String?
+  userAgent    String?
+  createdAt    DateTime @default(now())
+
+  @@index([userId])
+  @@index([resourceType])
+  @@index([createdAt])
+  @@map("audit_logs")
+}
+```
+
+## Utility (`lib/audit.ts`)
+
+```typescript
+interface AuditLogInput {
+  userId: string;
+  userName: string;
+  action: "CREATE" | "UPDATE" | "DELETE" | "LOGIN" | "EXPORT" | "SYNC";
+  resourceType: string;
+  resourceId?: string;
+  oldValues?: Record<string, unknown>;
+  newValues?: Record<string, unknown>;
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+async function logAction(input: AuditLogInput): Promise<void>
+```
+
+This function is called from every admin API route after a successful mutation:
+
+```typescript
+// Example in sermon creation
+const sermon = await prisma.sermon.create({ data: validatedData });
+await logAction({
+  userId: user.id,
+  userName: user.displayName,
+  action: "CREATE",
+  resourceType: "sermon",
+  resourceId: sermon.id,
+  newValues: validatedData,
+});
+```
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `AuditLogTable` | Filterable, paginated log table with expandable rows |
+| `AuditLogFilters` | User selector, action type, resource type, date range pickers |
+| `AuditLogDetail` | Expandable row showing JSON diff (old vs new values) |
+| `AuditLogExport` | Button to trigger CSV export of filtered results |
+
+## Pages
+
+| Route | Description |
+|-------|-------------|
+| `app/[locale]/admin/audit-log/page.tsx` | Audit log viewer with filters |
+
+## API Endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/admin/audit-log` | Paginated log with filters |
+| `GET` | `/api/admin/audit-log/export` | CSV download |
+
+## Query Parameters (GET /api/admin/audit-log)
+
+```typescript
+GetAuditLogQuerySchema {
+  page: number         // default 1
+  limit: number        // default 50, max 100
+  userId?: string      // filter by actor
+  action?: string      // filter by action type
+  resourceType?: string // filter by resource
+  dateFrom?: string    // ISO date
+  dateTo?: string      // ISO date
+  sortOrder?: "asc" | "desc" // default desc (newest first)
+}
+```
+
+## Retention Policy
+
+- Default: keep logs for 12 months
+- Configurable via environment variable `AUDIT_LOG_RETENTION_MONTHS`
+- Cron job or periodic cleanup: `DELETE FROM audit_logs WHERE createdAt < NOW() - INTERVAL '12 months'`
+- Can be triggered via `/api/admin/audit-log/cleanup` (SUPER_ADMIN only)
+
+## Dashboard Integration
+
+The admin dashboard shows the 10 most recent audit log entries as a "Recent Activity" feed.
+
+## Permissions Required
+
+- `audit.view` — view audit log
+- `audit.export` — export audit log as CSV
+
+## Dependencies
+
+- Requires: Admin Infrastructure
+- Existing: Prisma, `date-fns`
+- No new npm packages

--- a/docs/features/bible-lookup.md
+++ b/docs/features/bible-lookup.md
@@ -1,0 +1,131 @@
+# Bible Lookup (Enhanced)
+
+## Overview
+
+Enhance the existing Bible lookup tool at `/tools/bible`. Currently a basic search form that opens results in a popup window. The enhanced version adds inline results, multiple Bible versions, parallel Chinese/English view, chapter browsing, and verse sharing.
+
+## Current State
+
+- Basic search form at `app/[locale]/tools/bible/page.tsx`
+- Opens results in a popup window via `window.open()`
+- Result page fetches from external API (`bible.fhl.net`)
+- Minimal UI with just a search input
+
+## Enhanced Functionality
+
+### Inline Search Results
+- Show results on the same page below the search input (no popup window)
+- Display verse text with book, chapter, and verse numbers
+- Highlight search matches
+
+### Multiple Bible Versions
+- Chinese Union Version (CUV / 和合本) — current
+- English Standard Version (ESV)
+- New International Version (NIV)
+- King James Version (KJV)
+- Version selector dropdown
+
+### Parallel View
+- Side-by-side Chinese + English display
+- Synced scrolling between the two columns
+- Toggle between parallel and single-version view
+
+### Chapter Browsing
+- Navigate by Book > Chapter > Verse
+- Sidebar with all 66 books organized by Old/New Testament
+- Chapter list when a book is selected
+- Full chapter reading view with verse numbers
+- Previous/next chapter navigation
+
+### Bookmarks (requires auth)
+- Save favorite verses to personal collection
+- View saved bookmarks in member corner
+- Tag/categorize bookmarks
+
+### Verse Actions
+- Copy verse to clipboard with reference formatting
+- Share verse as styled image (for social media)
+- Direct link to specific verse
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `BibleSearch` | Enhanced search with version selector and book name auto-complete |
+| `BibleReader` | Chapter-by-chapter reading view with verse highlighting |
+| `BibleParallelView` | Side-by-side Chinese/English display |
+| `BibleBookNav` | Book/chapter navigation sidebar (OT/NT sections) |
+| `VerseCard` | Styled verse display with copy/share actions |
+| `VerseShareImage` | Canvas-based verse image generator |
+| `BibleVersionSelector` | Dropdown to choose Bible version |
+| `BookmarkButton` | Save/unsave verse bookmark |
+
+## Pages
+
+| Route | Description |
+|-------|-------------|
+| `app/[locale]/tools/bible/page.tsx` | Enhanced search + results (replaces current) |
+| `app/[locale]/tools/bible/[book]/[chapter]/page.tsx` | Chapter reading view |
+
+## API Endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/tools/bible/search` | Search verses (proxy to Bible API) |
+| `GET` | `/api/tools/bible/[book]/[chapter]` | Fetch full chapter |
+| `GET` | `/api/tools/bible/books` | List all books with chapter counts |
+| `POST` | `/api/member/me/bookmarks` | Save bookmark (auth required) |
+| `GET` | `/api/member/me/bookmarks` | List saved bookmarks |
+| `DELETE` | `/api/member/me/bookmarks/[id]` | Remove bookmark |
+
+## Data Source Options
+
+### Option A: External API (current approach, enhanced)
+- Continue using `bible.fhl.net` for Chinese text
+- Add ESV API (`api.esv.org`) for English text
+- Proxy through Next.js API routes to handle CORS and caching
+
+### Option B: Local Database (recommended for reliability)
+- Import CUV and one English version into PostgreSQL
+- Prisma model for Bible verses
+- Instant responses, no external dependency
+- ~31,000 verses per version
+
+```prisma
+model BibleVerse {
+  id       String @id @default(cuid())
+  version  String // "CUV", "ESV", etc.
+  book     String // "Genesis", "创世记"
+  bookNum  Int    // 1-66
+  chapter  Int
+  verse    Int
+  text     String @db.Text
+
+  @@unique([version, bookNum, chapter, verse])
+  @@index([version, bookNum, chapter])
+  @@map("bible_verses")
+}
+```
+
+## Query Parameters (GET /api/tools/bible/search)
+
+```typescript
+BibleSearchQuerySchema {
+  q: string           // search query (e.g. "Eph 2:1" or keyword)
+  version: string     // "CUV" | "ESV" | "NIV" | "KJV"
+  mode?: string       // "reference" | "keyword" (auto-detected)
+}
+```
+
+## i18n Keys
+
+Expand existing `"Tools.bible"` namespace with:
+- Version names, book names (en/zh), navigation labels
+- Copy/share action labels, bookmark labels
+- Chapter/verse labels
+
+## Dependencies
+
+- Existing: `dark-blue`, `zod`, `axios`
+- Optional new: `html2canvas` or `@napi-rs/canvas` for verse image generation
+- If using local DB: Prisma model + seed script with Bible text data

--- a/docs/features/content-management.md
+++ b/docs/features/content-management.md
@@ -1,0 +1,147 @@
+# Content Management
+
+## Overview
+
+A general CMS for managing static page content (About pages, Vision, Confession of Faith, etc.) so that church leadership can update content without code changes. Supports bilingual editing and version history.
+
+## Core Objectives
+
+- **Bilingual Editing**: Side-by-side English/Chinese content editing
+- **Rich Text**: WYSIWYG editor for formatted content
+- **Version History**: Track all content revisions with diff view
+- **Media Management**: Upload and manage images used in pages
+- **Draft/Publish Workflow**: Preview content before going live
+
+## Functionality
+
+- List all manageable content pages with status indicators
+- Rich text editor for each page's content (bilingual: en + zh fields)
+- Preview content as it would appear on the public site
+- Version history with revision comparison
+- Media upload for images used in page content
+- Draft → Published workflow with scheduled publishing
+
+## Prisma Schema Additions
+
+```prisma
+model ContentPage {
+  id          String            @id @default(cuid())
+  slug        String            @unique  // e.g. "about/vision"
+  titleEn     String
+  titleZh     String
+  contentEn   String            @db.Text
+  contentZh   String            @db.Text
+  status      ContentStatus     @default(DRAFT)
+  publishedAt DateTime?
+  authorId    String            // Stack Auth user ID
+  revisions   ContentRevision[]
+  createdAt   DateTime          @default(now())
+  updatedAt   DateTime          @updatedAt
+
+  @@map("content_pages")
+}
+
+enum ContentStatus {
+  DRAFT
+  PUBLISHED
+}
+
+model ContentRevision {
+  id            String      @id @default(cuid())
+  contentPageId String
+  contentPage   ContentPage @relation(fields: [contentPageId], references: [id])
+  titleEn       String
+  titleZh       String
+  contentEn     String      @db.Text
+  contentZh     String      @db.Text
+  editedById    String      // Stack Auth user ID
+  createdAt     DateTime    @default(now())
+
+  @@map("content_revisions")
+}
+
+model MediaAsset {
+  id           String   @id @default(cuid())
+  url          String
+  altText      String?
+  fileName     String
+  fileType     String   // e.g. "image/png"
+  fileSize     Int      // bytes
+  uploadedById String
+  createdAt    DateTime @default(now())
+
+  @@map("media_assets")
+}
+```
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `ContentPageList` | Table of all content pages with status badges and last-edited date |
+| `ContentEditor` | Rich text editor with side-by-side en/zh editing panes |
+| `ContentPreview` | Renders content as it would appear on the public site |
+| `RevisionHistory` | List of past versions with timestamps and editors |
+| `RevisionDiff` | Side-by-side comparison of two content versions |
+| `MediaUploader` | Drag-and-drop image upload with preview |
+| `MediaLibrary` | Browseable grid of uploaded media assets |
+
+## Pages
+
+| Route | Description |
+|-------|-------------|
+| `app/[locale]/admin/content/page.tsx` | Content page list |
+| `app/[locale]/admin/content/[slug]/page.tsx` | Edit specific content page |
+| `app/[locale]/admin/content/[slug]/revisions/page.tsx` | Revision history |
+| `app/[locale]/admin/media/page.tsx` | Media library |
+
+## API Endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/admin/content` | List all content pages |
+| `GET` | `/api/admin/content/[slug]` | Get content page by slug |
+| `PATCH` | `/api/admin/content/[slug]` | Update content (auto-creates revision) |
+| `POST` | `/api/admin/content/[slug]/publish` | Publish a draft |
+| `GET` | `/api/admin/content/[slug]/revisions` | List revisions |
+| `GET` | `/api/admin/content/[slug]/revisions/[id]` | Get specific revision |
+| `POST` | `/api/admin/media/upload` | Upload media file |
+| `GET` | `/api/admin/media` | List media assets |
+| `DELETE` | `/api/admin/media/[id]` | Delete media asset |
+
+## Rich Text Editor
+
+**Recommended library:** Tiptap (headless, extensible, React-friendly)
+
+Key features needed:
+- Headings (H1-H3), bold, italic, underline
+- Ordered/unordered lists
+- Links, images (from media library)
+- Block quotes
+- Tables (for meeting times, etc.)
+- HTML source view for advanced users
+
+## Media Storage
+
+- Use Vercel Blob Storage for file uploads (already on Vercel)
+- Alternative: Cloudflare R2 or AWS S3
+- Max file size: 5MB for images
+- Accepted types: image/png, image/jpeg, image/webp, image/gif
+
+## Public-Side Integration
+
+Existing static pages (About, Vision, etc.) would be refactored to fetch content from the ContentPage model instead of hardcoding text in translations. The i18n system remains for UI chrome, but page body content comes from the CMS.
+
+## Permissions Required
+
+- `content.view` — view content pages
+- `content.edit` — edit content
+- `content.publish` — publish drafts
+- `media.upload` — upload media
+- `media.delete` — delete media
+
+## Dependencies
+
+- Requires: Admin Infrastructure, Permission system
+- New packages: `@tiptap/react`, `@tiptap/starter-kit`, `@vercel/blob`
+- Existing: `dark-blue`, `zod`

--- a/docs/features/event-management.md
+++ b/docs/features/event-management.md
@@ -1,0 +1,176 @@
+# Event Management
+
+## Overview
+
+Manage church events (retreats, holiday gatherings, special services, fellowship events) that display on the public site and integrate with the member corner. Includes both admin management and public-facing event pages.
+
+## Core Objectives
+
+- **Event CRUD**: Create, edit, delete, and publish events
+- **Calendar View**: Visual calendar for admins and public users
+- **Registration**: Track member sign-ups for events
+- **Recurring Events**: Support weekly/monthly recurring events
+- **Public Display**: Events listing and detail pages for site visitors
+
+## Functionality
+
+### Admin Side
+- Create/edit/delete events with bilingual title and description
+- Fields: title (en/zh), description (en/zh), start/end datetime, location, type, recurring flag, recurrence rule, registration URL, cover image
+- Calendar view (month/week) and list view toggle
+- Publish/draft/cancel/archive workflow
+- Event registration list per event
+- Recurring event support with recurrence patterns
+
+### Public Side
+- Upcoming events listing (only PUBLISHED, future events)
+- Event detail page with registration link
+- Calendar view for browsing events by month
+- Integration with home page "Upcoming Events" section
+
+## Prisma Schema Additions
+
+```prisma
+model Event {
+  id              String              @id @default(cuid())
+  titleEn         String
+  titleZh         String
+  descriptionEn   String?             @db.Text
+  descriptionZh   String?             @db.Text
+  startDate       DateTime
+  endDate         DateTime?
+  location        String?
+  type            EventType           @default(OTHER)
+  isRecurring     Boolean             @default(false)
+  recurrenceRule  String?             // iCal RRULE format, e.g. "FREQ=WEEKLY;BYDAY=SU"
+  registrationUrl String?
+  coverImage      String?
+  status          EventStatus         @default(DRAFT)
+  createdById     String
+  registrations   EventRegistration[]
+  createdAt       DateTime            @default(now())
+  updatedAt       DateTime            @updatedAt
+
+  @@map("events")
+}
+
+enum EventType {
+  WORSHIP
+  FELLOWSHIP
+  RETREAT
+  CONFERENCE
+  HOLIDAY
+  OTHER
+}
+
+enum EventStatus {
+  DRAFT
+  PUBLISHED
+  CANCELLED
+  ARCHIVED
+}
+
+model EventRegistration {
+  id           String                   @id @default(cuid())
+  eventId      String
+  event        Event                    @relation(fields: [eventId], references: [id])
+  memberId     String?
+  name         String                   // For non-member registrations
+  email        String?
+  status       EventRegistrationStatus  @default(REGISTERED)
+  registeredAt DateTime                 @default(now())
+
+  @@map("event_registrations")
+}
+
+enum EventRegistrationStatus {
+  REGISTERED
+  CANCELLED
+}
+```
+
+## Components
+
+### Admin Components
+| Component | Purpose |
+|-----------|---------|
+| `EventAdminTable` | List view with filters (date range, type, status) |
+| `EventCalendarAdmin` | Month/week calendar grid with event cards |
+| `EventForm` | Create/edit form with datetime pickers, rich text description |
+| `EventRegistrationList` | Table of registered members for a specific event |
+
+### Public Components
+| Component | Purpose |
+|-----------|---------|
+| `EventList` | Upcoming events cards for public listing |
+| `EventDetail` | Public event detail with registration CTA |
+| `EventCalendarPublic` | Read-only month calendar for browsing |
+| `UpcomingEventsWidget` | Compact list for home page sidebar |
+
+## Pages
+
+### Admin
+| Route | Description |
+|-------|-------------|
+| `app/[locale]/admin/events/page.tsx` | Event list/calendar admin view |
+| `app/[locale]/admin/events/[id]/page.tsx` | Event detail/edit |
+| `app/[locale]/admin/events/[id]/registrations/page.tsx` | Registration list |
+
+### Public
+| Route | Description |
+|-------|-------------|
+| `app/[locale]/events/page.tsx` | Public events listing + calendar |
+| `app/[locale]/events/[id]/page.tsx` | Public event detail |
+
+## API Endpoints
+
+### Admin
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/admin/events` | Paginated list with filters |
+| `POST` | `/api/admin/events` | Create event |
+| `GET` | `/api/admin/events/[id]` | Get event details |
+| `PATCH` | `/api/admin/events/[id]` | Update event |
+| `DELETE` | `/api/admin/events/[id]` | Delete event |
+| `GET` | `/api/admin/events/[id]/registrations` | List registrations |
+
+### Public
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/events` | Public list (PUBLISHED, future only) |
+| `GET` | `/api/events/[id]` | Public event detail |
+| `POST` | `/api/events/[id]/register` | Register for event |
+
+## Zod Validation Schemas
+
+```typescript
+EventCreateSchema     // titleEn, titleZh (required), startDate (required), + optional fields
+EventUpdateSchema     // All fields partial
+GetEventsQuerySchema  // page, limit, type, status, dateFrom, dateTo, sortBy, sortOrder
+EventRegistrationSchema // name (required), email (optional)
+```
+
+## Calendar Implementation
+
+Use a lightweight calendar library or build a simple CSS Grid-based month view:
+- Each day cell shows event dots/chips
+- Click a day to see events for that day
+- Navigation: previous/next month, today button
+
+## i18n Keys
+
+Add `"Events"` and `"EventManagement"` namespaces for public and admin views.
+
+## Permissions Required
+
+- `events.view` — view events admin list
+- `events.create` — create events
+- `events.edit` — edit events
+- `events.delete` — delete events
+- `events.registrations` — view registration lists
+
+## Dependencies
+
+- Requires: Admin Infrastructure, Permission system
+- Existing: `dark-blue`, `zod`, `date-fns`
+- Optional: calendar library (e.g. `@schedule-x/react`) or custom CSS Grid calendar

--- a/docs/features/live-translation.md
+++ b/docs/features/live-translation.md
@@ -1,0 +1,160 @@
+# Live Translation
+
+## Overview
+
+A real-time translation tool for use during bilingual church services. A translator types the translation live, and attendees see it instantly on their phones or on a projected screen.
+
+## Core Objectives
+
+- **Real-Time Broadcast**: Operator types, all viewers see it instantly
+- **Multiple View Modes**: Operator input, projection display, mobile audience view
+- **Session Management**: Create and end translation sessions tied to service dates
+- **History**: Past sessions are saved and reviewable
+
+## Functionality
+
+### Operator View (auth-protected)
+- Text input area for typing translations in real-time
+- Source/target language toggle (Chinese ↔ English)
+- Font size controls for the display
+- Session start/end controls
+- View connected audience count
+
+### Display View (for projection)
+- Large-font, auto-scrolling text optimized for projection
+- Shows current and previous sentences
+- Configurable background color and font size
+- No UI chrome — full-screen text only
+- Auto-advances as new text arrives
+
+### Audience View (mobile-friendly, public)
+- Attendees open a URL on their phone
+- See the live translation stream
+- Configurable font size
+- Scroll through recent entries
+- Works without authentication
+
+## Prisma Schema Additions
+
+```prisma
+model TranslationSession {
+  id             String             @id @default(cuid())
+  title          String
+  date           DateTime
+  sourceLanguage String             @default("zh")
+  targetLanguage String             @default("en")
+  status         TranslationSessionStatus @default(ACTIVE)
+  createdById    String
+  entries        TranslationEntry[]
+  createdAt      DateTime           @default(now())
+
+  @@map("translation_sessions")
+}
+
+enum TranslationSessionStatus {
+  ACTIVE
+  ENDED
+}
+
+model TranslationEntry {
+  id        String             @id @default(cuid())
+  sessionId String
+  session   TranslationSession @relation(fields: [sessionId], references: [id])
+  text      String
+  sequence  Int
+  timestamp DateTime           @default(now())
+
+  @@map("translation_entries")
+}
+```
+
+## Technical Approach: Server-Sent Events (SSE)
+
+SSE is preferred over WebSocket for this use case because:
+- Communication is one-directional (operator → viewers)
+- SSE is simpler to implement with Next.js API routes
+- Built-in browser reconnection handling
+- No additional infrastructure needed
+
+### Flow:
+1. Operator creates a session via POST
+2. Operator types and submits text entries via POST
+3. Viewers connect to an SSE endpoint and receive entries in real-time
+4. On session end, SSE stream closes
+
+### Alternative (production scale):
+If concurrent viewer count exceeds ~100, consider using:
+- Ably or Pusher for managed pub/sub
+- Vercel Edge Runtime for SSE at edge
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `TranslationOperator` | Text input with send button, session controls, viewer count |
+| `TranslationDisplay` | Large-text projection view with auto-scroll |
+| `TranslationViewer` | Mobile-optimized read-only view with scrollable history |
+| `SessionManager` | Create/end sessions, view past sessions |
+| `SessionHistory` | List of past sessions with entry counts |
+
+## Pages
+
+| Route | Description |
+|-------|-------------|
+| `app/[locale]/tools/live-translation/page.tsx` | Public audience viewer |
+| `app/[locale]/tools/live-translation/operate/page.tsx` | Operator view (auth-protected) |
+| `app/[locale]/tools/live-translation/display/page.tsx` | Projection display view |
+| `app/[locale]/tools/live-translation/history/page.tsx` | Past session browser |
+
+## API Endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/tools/translation/sessions` | List sessions |
+| `POST` | `/api/tools/translation/sessions` | Create session |
+| `PATCH` | `/api/tools/translation/sessions/[id]` | End session |
+| `POST` | `/api/tools/translation/sessions/[id]/entries` | Add text entry |
+| `GET` | `/api/tools/translation/sessions/[id]/entries` | Get all entries (for history) |
+| `GET` | `/api/tools/translation/sessions/[id]/stream` | SSE endpoint for live stream |
+
+## SSE Endpoint Implementation
+
+```typescript
+// GET /api/tools/translation/sessions/[id]/stream
+export async function GET(request: NextRequest, { params }) {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      // Send existing entries as initial data
+      // Subscribe to new entries
+      // On new entry: controller.enqueue(encoder.encode(`data: ${JSON.stringify(entry)}\n\n`))
+      // On session end: controller.close()
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      "Connection": "keep-alive",
+    },
+  });
+}
+```
+
+## i18n Keys
+
+Add `"LiveTranslation"` namespace covering:
+- Operator controls, viewer labels, session management text
+- Connection status messages
+
+## Permissions Required
+
+- `tools.translation.operate` — access operator view, create/manage sessions
+- Public viewer: no auth required
+
+## Dependencies
+
+- Requires: Admin Infrastructure (for operator auth)
+- Existing: `dark-blue`, Prisma
+- No new npm packages (SSE is native browser + Node.js)

--- a/docs/features/member-corner.md
+++ b/docs/features/member-corner.md
@@ -1,0 +1,170 @@
+# Member Corner
+
+## Overview
+
+A self-service area for authenticated users. What a user can see depends on their membership status — users who have signed up but are not yet approved see a pending state; approved members get full access to member-only content.
+
+## Core Objectives
+
+- **Membership Request**: Any user who signs up is treated as a membership applicant (status PENDING)
+- **Approval Gate**: Only admin-approved members (status ACTIVE) can access member-only content
+- **Profile Management**: Approved members view and edit their own information
+- **Group Visibility**: See assigned fellowship groups and ministry roles
+- **Member-Only Content**: Access restricted announcements and resources
+- **Prayer Requests**: Submit prayer requests to the church (approved members only)
+
+## Membership Lifecycle
+
+```
+User signs up via Stack Auth
+        ↓
+Member record created with status = PENDING
+        ↓
+User sees "pending approval" state in /my-account
+(can edit basic profile info, but cannot access member-only content)
+        ↓
+Admin reviews request in Member Management
+        ↓
+  ┌─── Approve ──→ status = ACTIVE  → full member access
+  └─── Reject  ──→ status = REJECTED → user sees rejection notice
+```
+
+### Status Definitions
+
+| Status | Meaning | Access Level |
+|--------|---------|--------------|
+| `PENDING` | Signed up, awaiting admin approval | Can view/edit own basic profile only |
+| `ACTIVE` | Approved member | Full member-only content, prayer requests, groups |
+| `INACTIVE` | Deactivated by admin | Same as PENDING (no member content) |
+| `REJECTED` | Membership request denied | Sees rejection notice, can re-apply |
+
+## Functionality
+
+### For PENDING users:
+- See a "Your membership request is pending approval" banner
+- View and edit basic profile fields (name, phone, email) so admin can review accurate info
+- Cannot access member-only announcements, prayer requests, or group info
+
+### For ACTIVE members:
+- View/edit full profile (name, phone, email, address, birthday, baptism date)
+- View assigned fellowship groups and ministry assignments
+- Access member-only announcements and resources
+- Submit prayer requests with optional anonymity
+- View own prayer request history
+
+### For REJECTED users:
+- See a "Your membership request was not approved" notice with optional reason
+- Option to re-apply (resets status to PENDING)
+
+## Prisma Schema Additions
+
+```prisma
+model Member {
+  id                 String              @id @default(cuid())
+  userId             String              @unique  // FK to Stack Auth user ID
+  name               String
+  nameZh             String?
+  email              String?
+  phone              String?
+  address            String?
+  birthday           DateTime?
+  baptismDate        DateTime?
+  memberSince        DateTime?
+  status             MemberStatus        @default(PENDING)
+  rejectionReason    String?
+  approvedById       String?             // Stack Auth user ID of approving admin
+  approvedAt         DateTime?
+  fellowshipGroup    String?
+  ministryAssignments String[]
+  profilePhoto       String?
+  prayerRequests     PrayerRequest[]
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @updatedAt
+
+  @@map("members")
+}
+
+enum MemberStatus {
+  PENDING
+  ACTIVE
+  INACTIVE
+  REJECTED
+}
+
+model PrayerRequest {
+  id          String              @id @default(cuid())
+  memberId    String
+  member      Member              @relation(fields: [memberId], references: [id])
+  content     String
+  isAnonymous Boolean             @default(false)
+  status      PrayerRequestStatus @default(PENDING)
+  createdAt   DateTime            @default(now())
+
+  @@map("prayer_requests")
+}
+
+enum PrayerRequestStatus {
+  PENDING
+  PRAYED
+}
+```
+
+**Key change:** `MemberStatus` defaults to `PENDING` (not `ACTIVE`), and new fields `rejectionReason`, `approvedById`, `approvedAt` track the approval workflow.
+
+## Auto-Creation on Sign-Up
+
+When a user signs up via Stack Auth, a Member record is automatically created with status `PENDING`. This can be done via:
+
+- **Option A — Stack Auth webhook**: Configure a webhook on `user.created` that calls a local API route to create the Member record.
+- **Option B — On first `/my-account` visit**: If no Member record exists for the authenticated user, create one with status `PENDING` on page load (lazy creation).
+
+Option B is simpler and recommended for initial implementation.
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `MemberStatusBanner` | Shows pending/rejected/inactive status with appropriate messaging |
+| `MemberProfile` | Form with fields pre-filled from the Member record; editable |
+| `MemberDashboard` | Overview card with group info, upcoming events, recent announcements (ACTIVE only) |
+| `PrayerRequestForm` | Text area + anonymous toggle for submitting prayer requests (ACTIVE only) |
+| `PrayerRequestList` | List of own past prayer requests with status (ACTIVE only) |
+| `ReapplyButton` | For REJECTED users, resets status to PENDING |
+
+## Pages
+
+| Route | Description |
+|-------|-------------|
+| `app/[locale]/my-account/page.tsx` | Dashboard — content varies by member status |
+| `app/[locale]/my-account/profile/page.tsx` | Edit profile form (all statuses can access) |
+| `app/[locale]/my-account/prayer-requests/page.tsx` | Prayer requests (ACTIVE only, others redirected) |
+
+**Note:** This is a user-facing route (`/my-account`), not under `/admin`. Any authenticated user can access it, but content is gated by membership status.
+
+## API Endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/member/me` | Fetch current user's member profile (auto-creates PENDING if missing) |
+| `PATCH` | `/api/member/me` | Update current user's profile |
+| `POST` | `/api/member/me/reapply` | Reset status from REJECTED to PENDING |
+| `GET` | `/api/member/me/prayer-requests` | List own prayer requests (ACTIVE only) |
+| `POST` | `/api/member/me/prayer-requests` | Submit a new prayer request (ACTIVE only) |
+
+## Zod Validation Schemas
+
+- `MemberProfileUpdateSchema` — partial update for profile fields (name, nameZh, phone, email, address, birthday)
+- `PrayerRequestCreateSchema` — content (required), isAnonymous (boolean)
+
+## i18n Keys
+
+Add `"MemberCorner"` namespace covering:
+- Profile field labels, dashboard headings, prayer request form labels
+- Status banner messages: pending approval, rejected (with reason), inactive
+- Reapply button text
+- Success/error toasts
+
+## Dependencies
+
+- Requires: Admin Infrastructure (auth middleware), Member model in Prisma
+- Existing: `@stackframe/stack`, `dark-blue`, `zod`

--- a/docs/features/member-management.md
+++ b/docs/features/member-management.md
@@ -1,0 +1,149 @@
+# Member Management
+
+## Overview
+
+Admin interface to manage all church members — review membership requests, approve/reject applicants, edit member details, and perform bulk operations. This is the administrative counterpart to the self-service Member Corner.
+
+## Core Objectives
+
+- **Membership Approval**: Review and approve/reject sign-up requests
+- **Full CRUD**: Create, read, update, and deactivate member records
+- **Search & Filter**: Find members by name, phone, email, group, status
+- **Bulk Operations**: Import from CSV, export directory, bulk status changes
+- **Group Assignment**: Assign members to fellowship groups and ministries
+
+## Membership Approval Workflow
+
+When a user signs up, a Member record is automatically created with status `PENDING`. Admins manage these requests from the Member Management page.
+
+```
+Sign-up creates Member (PENDING)
+        ↓
+Admin sees request in "Pending Requests" tab/filter
+        ↓
+Admin reviews profile info submitted by the applicant
+        ↓
+  ┌─── Approve ──→ status = ACTIVE, approvedById + approvedAt set
+  │                 user gains member-only access
+  └─── Reject  ──→ status = REJECTED, rejectionReason set
+                    user sees rejection notice, can re-apply
+```
+
+### Approval Actions
+
+| Action | Effect |
+|--------|--------|
+| **Approve** | Sets status to `ACTIVE`, records `approvedById` and `approvedAt`, optionally assigns fellowship group |
+| **Reject** | Sets status to `REJECTED`, requires `rejectionReason` text |
+| **Deactivate** | Sets an ACTIVE member to `INACTIVE` (revokes access, keeps record) |
+| **Reactivate** | Sets INACTIVE back to `ACTIVE` |
+
+## Functionality
+
+- **Pending Requests tab**: Dedicated view showing only PENDING members, sorted by request date (newest first), with one-click approve/reject actions
+- Paginated member list with search (by name, phone, email, group)
+- Filter by status: Pending, Active, Inactive, Rejected
+- Add new member manually via form (auto-set to ACTIVE, skipping approval)
+- Edit all member fields
+- Deactivate/reactivate members (soft delete via status)
+- Assign members to fellowship groups and ministries
+- Export member directory as CSV (ACTIVE members only by default)
+- Bulk import from CSV/Excel (imported members default to ACTIVE)
+- View member activity history (linked to audit log)
+- Pending request count badge on admin sidebar
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `MemberTable` | Data table with sortable columns, search bar, status/group filters |
+| `MemberPendingList` | Specialized view for pending requests with approve/reject action buttons |
+| `MemberApproveDialog` | Confirmation dialog for approval, optional group assignment |
+| `MemberRejectDialog` | Dialog requiring a rejection reason |
+| `MemberForm` | Create/edit form dialog with Zod validation for all member fields |
+| `MemberDetail` | Full detail view with activity history and linked user account |
+| `MemberImportDialog` | CSV file upload with column mapping UI |
+| `MemberExportButton` | Triggers CSV download of filtered member list |
+| `MemberGroupAssign` | Multi-select dropdown to assign groups/ministries |
+| `PendingBadge` | Badge on admin sidebar showing count of pending requests |
+
+## Pages
+
+| Route | Description |
+|-------|-------------|
+| `app/[locale]/admin/members/page.tsx` | Member list with tabs: Pending / All Members |
+| `app/[locale]/admin/members/[id]/page.tsx` | Individual member detail/edit view |
+
+## API Endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/admin/members` | Paginated list with filters (including status filter) |
+| `POST` | `/api/admin/members` | Create new member (admin-created, defaults to ACTIVE) |
+| `GET` | `/api/admin/members/[id]` | Get single member |
+| `PATCH` | `/api/admin/members/[id]` | Update member fields |
+| `POST` | `/api/admin/members/[id]/approve` | Approve pending member |
+| `POST` | `/api/admin/members/[id]/reject` | Reject pending member (requires reason) |
+| `POST` | `/api/admin/members/[id]/deactivate` | Deactivate active member |
+| `POST` | `/api/admin/members/[id]/reactivate` | Reactivate inactive member |
+| `POST` | `/api/admin/members/import` | Bulk CSV import (imported as ACTIVE) |
+| `GET` | `/api/admin/members/export` | CSV export |
+| `GET` | `/api/admin/members/pending-count` | Count of PENDING members (for sidebar badge) |
+
+## Zod Validation Schemas
+
+```typescript
+MemberCreateSchema     // name (required), email, phone, address, birthday, baptismDate,
+                       // memberSince, fellowshipGroup, ministryAssignments[]
+                       // Note: status is NOT settable on create — admin-created = ACTIVE
+MemberUpdateSchema     // All fields partial (except status — use dedicated endpoints)
+MemberApproveSchema    // fellowshipGroup? (optional, assign on approval)
+MemberRejectSchema     // rejectionReason (required)
+GetMembersQuerySchema  // page, limit, search, status, fellowshipGroup, sortBy, sortOrder
+```
+
+## CSV Import Format
+
+```csv
+name,nameZh,email,phone,address,birthday,baptismDate,fellowshipGroup,ministryAssignments
+John Doe,张三,john@example.com,631-555-0100,123 Main St,1990-01-15,2020-06-01,Family Fellowship,"Choir,Finance"
+```
+
+Imported members are set to `ACTIVE` status (bypasses approval since admin is explicitly importing known members).
+
+## Admin Notifications
+
+- When a new membership request arrives (PENDING member created), show a notification dot on the admin sidebar "Members" link
+- Dashboard widget: "X pending membership requests" with a link to the pending list
+
+## Audit Log Integration
+
+All approval/rejection actions are logged:
+- `APPROVE_MEMBER` — records who approved, when
+- `REJECT_MEMBER` — records who rejected, reason, when
+- `DEACTIVATE_MEMBER` / `REACTIVATE_MEMBER`
+
+## i18n Keys
+
+Add `"MemberManagement"` namespace covering:
+- Table headers, filter labels, form field labels
+- Status labels: Pending, Active, Inactive, Rejected
+- Approval/rejection dialog text
+- Pending request count messages
+- Import/export dialog text, confirmation messages
+- Success/error messages
+
+## Permissions Required
+
+- `members.view` — view member list and details
+- `members.create` — add new members manually
+- `members.edit` — update member information
+- `members.approve` — approve/reject pending membership requests
+- `members.deactivate` — deactivate/reactivate members
+- `members.export` — download member directory
+- `members.import` — bulk import members
+
+## Dependencies
+
+- Requires: Admin Infrastructure, Member Prisma model, Permission system, Audit Log
+- Existing: `dark-blue` (DataTable pattern), `zod`

--- a/docs/features/permission-management.md
+++ b/docs/features/permission-management.md
@@ -1,0 +1,131 @@
+# Permission Management
+
+## Overview
+
+Define granular permissions that are assigned to roles. Permissions control what actions each role can perform across all admin modules. This feature works in tandem with Role Management.
+
+## Core Objectives
+
+- **Permission Registry**: Central list of all permission keys
+- **Resource Grouping**: Permissions organized by resource (Sermons, Members, Events, etc.)
+- **Permission Check Utility**: Reusable function for API routes and UI components
+- **Seed Script**: Auto-populate permissions on deployment
+
+## Permission Keys
+
+Permissions follow the convention `resource.action`:
+
+| Resource | Permissions |
+|----------|-------------|
+| `sermons` | `sermons.view`, `sermons.create`, `sermons.edit`, `sermons.delete`, `sermons.sync` |
+| `news` | `news.view`, `news.create`, `news.edit`, `news.delete` |
+| `members` | `members.view`, `members.create`, `members.edit`, `members.approve`, `members.deactivate`, `members.export`, `members.import` |
+| `events` | `events.view`, `events.create`, `events.edit`, `events.delete`, `events.registrations` |
+| `announcements` | `announcements.view`, `announcements.create`, `announcements.edit`, `announcements.delete` |
+| `content` | `content.view`, `content.edit`, `content.publish` |
+| `media` | `media.upload`, `media.delete` |
+| `users` | `users.view`, `users.edit`, `users.invite`, `users.disable`, `users.roles` |
+| `roles` | `roles.view`, `roles.create`, `roles.edit`, `roles.delete`, `roles.assign` |
+| `audit` | `audit.view`, `audit.export` |
+| `tools` | `tools.translation.operate`, `tools.ppt.generate` |
+
+## Utility Functions (`lib/permissions.ts`)
+
+```typescript
+// Check if a user has a specific permission
+async function hasPermission(userId: string, permissionKey: string): Promise<boolean>
+
+// Middleware helper for API routes — throws 403 if unauthorized
+async function requirePermission(userId: string, permissionKey: string): Promise<void>
+
+// Get all permissions for a user (aggregated from all their roles)
+async function getUserPermissions(userId: string): Promise<string[]>
+
+// Client-side hook for conditional UI rendering
+function usePermissions(): { permissions: string[], hasPermission: (key: string) => boolean }
+```
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `PermissionMatrix` | Grid showing roles (columns) vs permissions (rows) with checkboxes. Shared with Role Management. |
+| `PermissionGroupList` | Read-only list of all permissions grouped by resource |
+| `PermissionGate` | React wrapper component that conditionally renders children based on permission |
+
+### PermissionGate Usage
+
+```tsx
+<PermissionGate permission="sermons.edit">
+  <Button>Edit Sermon</Button>
+</PermissionGate>
+```
+
+## Pages
+
+Permission management is integrated into the Role Management page as a tab or section — no separate dedicated page. The permission matrix is displayed within `app/[locale]/admin/roles/[id]/page.tsx`.
+
+## API Endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/admin/permissions` | List all permissions grouped by resource |
+| `GET` | `/api/admin/permissions/mine` | Get current user's effective permissions |
+
+## Seed Script
+
+The Prisma seed script (shared with Role Management) populates all permission records:
+
+```typescript
+// prisma/seed.ts
+const permissions = [
+  { key: "sermons.view", name: "View Sermons", resource: "sermons", action: "view" },
+  { key: "sermons.create", name: "Create Sermons", resource: "sermons", action: "create" },
+  // ... all permissions
+];
+
+for (const perm of permissions) {
+  await prisma.permission.upsert({
+    where: { key: perm.key },
+    update: {},
+    create: perm,
+  });
+}
+```
+
+## Integration Pattern
+
+Every admin API route follows this pattern:
+
+```typescript
+export async function POST(request: NextRequest) {
+  const user = await stackServerApp.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  await requirePermission(user.id, "sermons.create");
+
+  // ... handle request
+}
+```
+
+Every admin UI component uses the client-side hook:
+
+```typescript
+const { hasPermission } = usePermissions();
+
+return (
+  <>
+    {hasPermission("sermons.edit") && <EditButton />}
+  </>
+);
+```
+
+## i18n Keys
+
+Permission names and descriptions should be translatable for the admin UI permission matrix.
+
+## Dependencies
+
+- Requires: Role Prisma models (Role, Permission, RolePermission, UserRole)
+- Existing: Prisma, `@stackframe/stack`
+- No new npm packages

--- a/docs/features/ppt-generation.md
+++ b/docs/features/ppt-generation.md
@@ -1,0 +1,194 @@
+# PPT Generation
+
+## Overview
+
+Auto-generate PowerPoint slides for Sunday worship services — hymn lyrics, scripture readings, sermon title slides, and announcements. Includes a hymn database and worship order builder.
+
+## Core Objectives
+
+- **Slide Generation**: Produce downloadable .pptx files from structured input
+- **Worship Order Builder**: Drag-and-drop interface for building service flow
+- **Hymn Database**: Searchable library of hymn lyrics (bilingual)
+- **Template System**: Configurable slide templates (colors, fonts, backgrounds)
+- **Bilingual Slides**: Generate slides with Chinese + English text
+
+## Functionality
+
+### Worship Order Builder
+- Drag-and-drop items to build the service order
+- Item types: Hymn, Scripture Reading, Sermon Title, Announcement, Custom Text
+- Reorder items, add/remove
+- Save/load worship orders for reuse
+- Preview generated slides before download
+
+### Hymn Database
+- Searchable library of hymn lyrics
+- Fields: hymn number, title (en/zh), lyrics (en/zh, array of verses), category
+- Add/edit/delete hymns (admin)
+- Import hymns from CSV or text files
+- Preview hymn lyrics with verse structure
+
+### Slide Templates
+- Pre-built templates: Title Slide, Hymn Lyrics, Scripture, Announcement
+- Configurable: background color/image, font size, font family, text alignment
+- Hymn slides: one verse per slide, large font
+- Scripture slides: verse text with reference
+- Bilingual layout: Chinese text on top, English below (or side-by-side)
+
+### Generation
+- Click "Generate" to produce a .pptx file
+- Download to local machine
+- Each worship order item becomes one or more slides
+
+## Prisma Schema Additions
+
+```prisma
+model Hymn {
+  id        String   @id @default(cuid())
+  number    Int?     @unique   // Hymnal number
+  titleEn   String
+  titleZh   String
+  lyricsEn  Json     // Array of verse strings
+  lyricsZh  Json     // Array of verse strings
+  category  String?  // e.g. "Praise", "Communion", "Christmas"
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("hymns")
+}
+
+model PptTemplate {
+  id           String  @id @default(cuid())
+  name         String
+  description  String?
+  templateData Json    // { bgColor, fontFamily, fontSize, textColor, layout, bgImage }
+  isDefault    Boolean @default(false)
+  createdAt    DateTime @default(now())
+
+  @@map("ppt_templates")
+}
+
+model WorshipOrder {
+  id          String             @id @default(cuid())
+  date        DateTime
+  title       String?            // e.g. "Sunday Worship - Jan 5, 2025"
+  items       WorshipOrderItem[]
+  createdById String
+  createdAt   DateTime           @default(now())
+  updatedAt   DateTime           @updatedAt
+
+  @@map("worship_orders")
+}
+
+model WorshipOrderItem {
+  id             String       @id @default(cuid())
+  worshipOrderId String
+  worshipOrder   WorshipOrder @relation(fields: [worshipOrderId], references: [id])
+  type           OrderItemType
+  sequence       Int
+  hymnId         String?      // If type = HYMN
+  scriptureRef   String?      // If type = SCRIPTURE, e.g. "John 3:16"
+  contentEn      String?      // For ANNOUNCEMENT or CUSTOM
+  contentZh      String?
+  createdAt      DateTime     @default(now())
+
+  @@map("worship_order_items")
+}
+
+enum OrderItemType {
+  HYMN
+  SCRIPTURE
+  SERMON_TITLE
+  ANNOUNCEMENT
+  CUSTOM
+}
+```
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `WorshipOrderBuilder` | Drag-and-drop interface for building service order |
+| `OrderItemCard` | Individual item in the worship order (draggable) |
+| `HymnSelector` | Searchable hymn picker with lyrics preview |
+| `ScriptureSelector` | Bible reference input with verse preview (reuses Bible Lookup API) |
+| `SlidePreview` | Preview of generated slides before download |
+| `TemplateEditor` | Admin UI to customize slide templates |
+| `HymnTable` | Admin list of all hymns with search and edit |
+| `HymnForm` | Create/edit hymn with verse-by-verse input |
+| `HymnImport` | Bulk import hymns from CSV/text |
+
+## Pages
+
+| Route | Description |
+|-------|-------------|
+| `app/[locale]/tools/ppt/page.tsx` | Worship order builder + slide generator |
+| `app/[locale]/admin/hymns/page.tsx` | Hymn database management |
+| `app/[locale]/admin/hymns/[id]/page.tsx` | Hymn detail/edit |
+| `app/[locale]/admin/templates/page.tsx` | Slide template management |
+
+## API Endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `POST` | `/api/tools/ppt/generate` | Generate .pptx from worship order JSON |
+| `GET` | `/api/admin/hymns` | List hymns with search |
+| `POST` | `/api/admin/hymns` | Create hymn |
+| `GET` | `/api/admin/hymns/[id]` | Get hymn |
+| `PATCH` | `/api/admin/hymns/[id]` | Update hymn |
+| `DELETE` | `/api/admin/hymns/[id]` | Delete hymn |
+| `POST` | `/api/admin/hymns/import` | Bulk import |
+| `GET` | `/api/admin/worship-orders` | List saved worship orders |
+| `POST` | `/api/admin/worship-orders` | Save worship order |
+| `GET` | `/api/admin/worship-orders/[id]` | Load worship order |
+| `GET` | `/api/admin/templates` | List slide templates |
+| `POST` | `/api/admin/templates` | Create template |
+| `PATCH` | `/api/admin/templates/[id]` | Update template |
+
+## PPTX Generation (`pptxgenjs`)
+
+```typescript
+import PptxGenJS from "pptxgenjs";
+
+function generatePptx(worshipOrder: WorshipOrderWithItems, template: PptTemplate): Buffer {
+  const pptx = new PptxGenJS();
+
+  for (const item of worshipOrder.items) {
+    switch (item.type) {
+      case "HYMN":
+        // One slide per verse, large centered text
+        for (const verse of item.hymn.lyricsZh) {
+          const slide = pptx.addSlide();
+          slide.addText(verse, { fontSize: 36, align: "center", valign: "middle" });
+        }
+        break;
+      case "SCRIPTURE":
+        // Single slide with verse text and reference
+        break;
+      case "SERMON_TITLE":
+        // Title slide with sermon name and speaker
+        break;
+      // ...
+    }
+  }
+
+  return pptx.write({ outputType: "nodebuffer" });
+}
+```
+
+## i18n Keys
+
+Add `"PptGeneration"` and `"HymnManagement"` namespaces.
+
+## Permissions Required
+
+- `tools.ppt.generate` — use the PPT generator
+- `hymns.view` — view hymn database
+- `hymns.edit` — add/edit/delete hymns
+- `templates.edit` — manage slide templates
+
+## Dependencies
+
+- Requires: Admin Infrastructure (for hymn/template management), Bible Lookup API (for scripture items)
+- New packages: `pptxgenjs` (PPTX generation), `@hello-pangea/dnd` (drag-and-drop)
+- Existing: `dark-blue`, `zod`, Prisma

--- a/docs/features/role-management.md
+++ b/docs/features/role-management.md
@@ -1,0 +1,131 @@
+# Role Management
+
+## Overview
+
+Define and manage roles that group permissions together. Roles like "Pastor", "Deacon", "Media Team", and "Admin" determine what each user can do in the admin portal.
+
+## Core Objectives
+
+- **Role CRUD**: Create, edit, and delete custom roles
+- **Permission Grouping**: Assign sets of permissions to each role
+- **User Assignment**: View and manage which users hold each role
+- **System Roles**: Built-in roles that cannot be deleted
+
+## Functionality
+
+- Create/edit/delete roles with name and description
+- Assign a set of permissions to each role via checkbox matrix
+- View which users are assigned to each role
+- System (built-in) roles cannot be deleted but can have permissions adjusted
+- Default roles seeded on first setup:
+  - `SUPER_ADMIN` — full access, system role
+  - `ADMIN` — full access except user/role management
+  - `PASTOR` — sermons, events, announcements, member view
+  - `DEACON` — events, announcements, member view
+  - `MEDIA_TEAM` — sermons, content, media upload
+  - `MEMBER` — member corner access only
+
+## Prisma Schema Additions
+
+```prisma
+model Role {
+  id          String           @id @default(cuid())
+  name        String           @unique
+  description String?
+  isSystem    Boolean          @default(false) // Prevents deletion of built-in roles
+  permissions RolePermission[]
+  users       UserRole[]
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+
+  @@map("roles")
+}
+
+model UserRole {
+  id         String   @id @default(cuid())
+  userId     String   // Stack Auth user ID
+  roleId     String
+  role       Role     @relation(fields: [roleId], references: [id])
+  assignedBy String?  // Stack Auth user ID of assigner
+  assignedAt DateTime @default(now())
+
+  @@unique([userId, roleId])
+  @@map("user_roles")
+}
+
+model Permission {
+  id          String           @id @default(cuid())
+  key         String           @unique  // e.g. "sermons.create"
+  name        String                    // e.g. "Create Sermons"
+  description String?
+  resource    String                    // e.g. "sermons"
+  action      String                    // e.g. "create"
+  roles       RolePermission[]
+
+  @@map("permissions")
+}
+
+model RolePermission {
+  roleId       String
+  permissionId String
+  role         Role       @relation(fields: [roleId], references: [id])
+  permission   Permission @relation(fields: [permissionId], references: [id])
+
+  @@id([roleId, permissionId])
+  @@map("role_permissions")
+}
+```
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `RoleTable` | List of roles with user count and permission summary |
+| `RoleForm` | Create/edit role with name, description fields |
+| `PermissionMatrix` | Grid: rows = permissions grouped by resource, columns = checkboxes |
+| `RoleUserList` | List of users assigned to a specific role, with remove action |
+| `RoleAssignDialog` | Assign a role to a user (used from User Management) |
+
+## Pages
+
+| Route | Description |
+|-------|-------------|
+| `app/[locale]/admin/roles/page.tsx` | Role list with permission matrix |
+| `app/[locale]/admin/roles/[id]/page.tsx` | Role detail: edit permissions, view assigned users |
+
+## API Endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/admin/roles` | List all roles with permission and user counts |
+| `POST` | `/api/admin/roles` | Create new role |
+| `GET` | `/api/admin/roles/[id]` | Get role with full permissions and user list |
+| `PATCH` | `/api/admin/roles/[id]` | Update role name/description |
+| `DELETE` | `/api/admin/roles/[id]` | Delete role (fails for system roles) |
+| `PATCH` | `/api/admin/roles/[id]/permissions` | Update role's permission set |
+| `POST` | `/api/admin/roles/[id]/users` | Assign user to role |
+| `DELETE` | `/api/admin/roles/[id]/users/[userId]` | Remove user from role |
+
+## Seed Script
+
+A Prisma seed script (`prisma/seed.ts`) to populate:
+1. All permission records (one per resource-action pair)
+2. Default system roles with their permission assignments
+
+## i18n Keys
+
+Add `"RoleManagement"` namespace.
+
+## Permissions Required
+
+- `roles.view` — view role list
+- `roles.create` — create roles
+- `roles.edit` — edit roles and their permissions
+- `roles.delete` — delete non-system roles
+- `roles.assign` — assign/remove users from roles
+
+## Dependencies
+
+- Requires: Admin Infrastructure
+- Existing: `dark-blue`, `zod`, Prisma
+- No new npm packages

--- a/docs/features/sermon-management.md
+++ b/docs/features/sermon-management.md
@@ -1,0 +1,83 @@
+# Sermon Management (Admin)
+
+## Overview
+
+Admin CRUD interface for sermons, complementing the existing scraper-only flow. Allows admins to manually create, edit, and manage sermons with media links, and to manually trigger the scraper sync.
+
+## Core Objectives
+
+- **Full Admin CRUD**: Create, edit, delete sermons from the admin panel
+- **Media Management**: Link audio/video files to sermons
+- **Scraper Integration**: Manual trigger for the existing sermon scraper
+- **Bulk Operations**: Multi-select delete, type change
+
+## Functionality
+
+- Paginated sermon list with all existing filters (search, speaker, series, type)
+- Create new sermon with all fields: title, speaker, date, type, series, scripture, description, audio/video URLs
+- Edit existing sermons inline or via detail page
+- Delete sermons (with confirmation)
+- Bulk actions: delete multiple, change type for multiple
+- Manual trigger for `/api/tasks/sync-sermons` from admin UI
+- View sync history and last sync timestamp
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `SermonAdminTable` | Data table reusing existing filter logic, with edit/delete actions per row |
+| `SermonAdminForm` | Create/edit form dialog with all sermon fields and Zod validation |
+| `SermonBulkActions` | Toolbar for multi-select operations (delete, change type) |
+| `SyncControls` | Button to trigger manual sync + last sync timestamp display |
+
+## Pages
+
+| Route | Description |
+|-------|-------------|
+| `app/[locale]/admin/sermons/page.tsx` | Sermon list with admin actions |
+| `app/[locale]/admin/sermons/[id]/page.tsx` | Sermon detail/edit view |
+
+## API Endpoints
+
+Existing endpoints already provide most functionality. Additions:
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `PATCH` | `/api/sermons/[id]` | Update sermon (add auth guard) |
+| `DELETE` | `/api/sermons/[id]` | Delete sermon (add auth guard) |
+| `POST` | `/api/admin/sermons/sync` | Manual sync trigger |
+| `POST` | `/api/admin/sermons/bulk` | Bulk operations (delete, change type) |
+
+**Note:** The existing `GET /api/sermons` and `POST /api/sermons` routes remain unchanged but need auth guards added for write operations.
+
+## Zod Validation Schemas
+
+Already defined in `lib/validations.ts`:
+- `SermonCreateSchema` — used for creation
+- `SermonUpdateSchema` — used for updates
+- `GetSermonsQuerySchema` — used for list filtering
+
+New addition:
+```typescript
+SermonBulkActionSchema // { ids: string[], action: "delete" | "changeType", type?: SermonType }
+```
+
+## Auth Guards
+
+- Read operations: public (no change)
+- Write operations (POST, PATCH, DELETE, bulk): require `sermons.edit` permission
+- Sync trigger: require `sermons.sync` permission
+
+## Permissions Required
+
+- `sermons.view` — view sermon list (public, no guard)
+- `sermons.create` — create sermons
+- `sermons.edit` — edit sermons
+- `sermons.delete` — delete sermons
+- `sermons.sync` — trigger manual sync
+
+## Dependencies
+
+- Requires: Admin Infrastructure, Permission system
+- Existing: `dark-blue`, `zod`, sermon API routes, scraper
+- No new npm packages

--- a/docs/features/user-management.md
+++ b/docs/features/user-management.md
@@ -1,0 +1,116 @@
+# User Management
+
+## Overview
+
+Manage Stack Auth user accounts — view all registered users, see their membership status, enable/disable accounts, and invite new users. This is the bridge between the authentication system (Stack Auth) and the local Member data model.
+
+## Core Objectives
+
+- **User Directory**: View all Stack Auth users with their metadata and membership status
+- **Account Control**: Enable/disable user accounts
+- **Invitations**: Invite new users via email
+- **Role Assignment**: Assign roles to users (links to Role Management)
+- **Membership Visibility**: See each user's membership status (Pending/Active/Inactive/Rejected) at a glance
+
+## Relationship to Member Management
+
+User Management and Member Management work together but serve different purposes:
+
+| Concern | User Management | Member Management |
+|---------|-----------------|-------------------|
+| **Data source** | Stack Auth (external) | Local Prisma `Member` table |
+| **Scope** | Authentication, account access | Church membership, profile, groups |
+| **Key actions** | Enable/disable accounts, assign roles | Approve/reject requests, manage profiles |
+| **Who** | All people with an account | People who requested or have membership |
+
+The link between the two is `Member.userId` which stores the Stack Auth user ID. When a user signs up, a Member record is auto-created with status `PENDING`. The admin approves membership via Member Management, and assigns roles via User Management.
+
+## Functionality
+
+- List all Stack Auth users with email, last login, created date, linked member status
+- See membership status inline: PENDING (needs approval), ACTIVE, INACTIVE, REJECTED, or "No request" (admin-only accounts)
+- Disable/enable user accounts via Stack Auth API
+- Invite new users by email (sends Stack Auth invitation)
+- View and manage user's assigned roles
+- Search users by name or email
+- Quick link to the linked Member record in Member Management
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `UserTable` | List of Stack Auth users with membership status badge and role badges |
+| `UserDetail` | Full user view: auth info + linked member status + role assignments |
+| `UserInviteDialog` | Email invite form with optional role pre-assignment |
+| `UserRoleManager` | Checkbox list to assign/remove roles for a user |
+| `MemberStatusChip` | Inline badge showing linked member's status (Pending/Active/etc.) |
+
+## Pages
+
+| Route | Description |
+|-------|-------------|
+| `app/[locale]/admin/users/page.tsx` | User list with search and filters |
+| `app/[locale]/admin/users/[id]/page.tsx` | User detail with membership status and roles |
+
+## API Endpoints
+
+All endpoints use Stack Auth's server-side SDK (`stackServerApp`) combined with local database queries.
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/admin/users` | List users (Stack Auth + join with Member status) |
+| `GET` | `/api/admin/users/[id]` | Get user detail |
+| `PATCH` | `/api/admin/users/[id]` | Update user metadata |
+| `POST` | `/api/admin/users/invite` | Send email invitation |
+| `POST` | `/api/admin/users/[id]/disable` | Disable user account |
+| `POST` | `/api/admin/users/[id]/enable` | Enable user account |
+| `GET` | `/api/admin/users/[id]/roles` | List user's roles |
+| `PATCH` | `/api/admin/users/[id]/roles` | Update user's role assignments |
+
+## Data Flow
+
+```
+User signs up via Stack Auth
+        ↓
+Stack Auth account created (email, password)
+        ↓
+Member record auto-created (status = PENDING)
+        ↓
+Admin sees user in User Management with "Pending" membership badge
+        ↓
+Admin clicks through to Member Management to approve/reject
+        ↓
+Admin assigns roles in User Management (optional)
+```
+
+The `Member.userId` field stores the Stack Auth user ID, creating a 1:1 link. Not all Stack Auth users must have a Member record (e.g., admin-only accounts that were created before the membership system), though the default flow auto-creates one.
+
+## Zod Validation Schemas
+
+```typescript
+UserInviteSchema        // email (required), roles[] (optional)
+UserUpdateSchema        // metadata (optional)
+UserRoleUpdateSchema    // roleIds: string[]
+GetUsersQuerySchema     // page, limit, search, memberStatus, role, sortBy, sortOrder
+```
+
+## i18n Keys
+
+Add `"UserManagement"` namespace covering:
+- Table headers, detail labels, invite dialog text
+- Status labels (Active, Disabled), membership status labels
+- Confirmation messages for enable/disable actions
+
+## Permissions Required
+
+- `users.view` — view user list and details
+- `users.edit` — update user metadata
+- `users.invite` — send invitations
+- `users.disable` — disable/enable accounts
+- `users.roles` — assign/remove roles
+
+## Dependencies
+
+- Requires: Admin Infrastructure, Member model, Role/Permission models
+- Existing: `@stackframe/stack`, `dark-blue`, `zod`
+- No new npm packages (Stack Auth SDK handles user operations)


### PR DESCRIPTION
## Summary

- Add 14 detailed feature plan documents in `docs/features/` covering all planned admin portal, tool portal, and infrastructure features
- Restructure `docs/TODO.md` into a phased roadmap with dependency tracking, status legend, Prisma schema overview, and package dependency summary
- Update `CLAUDE.md` with a "Roadmap & Feature Plans" section for future session context

### Feature plans added:

**Admin Portal (Phase 1-3)**
- Admin Infrastructure (shared layout, auth middleware, dashboard)
- Role Management, Permission Management, Audit Log
- User Management, Member Management (with approval workflow), Member Corner
- Sermon Management, Announcement Management, Event Management, Content Management (CMS)

**Tool Portal (Phase 4)**
- Bible Lookup (enhanced with parallel view, chapter browsing)
- PPT Generation (worship order builder + hymn database)
- Live Translation (real-time SSE for bilingual services)

### Key design decision:
Membership uses an **approval-based flow** — sign-ups create a PENDING member record; only admin-approved members gain access to member-only content.

## Test plan

- [ ] Verify all markdown files render correctly on GitHub
- [ ] Verify all cross-links between TODO.md and feature plans resolve
- [ ] Review feature plans for completeness and consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)