### PR TITLE
feat: implement Phase 1 admin infrastructure, roles, permissions, and…

### DIFF
--- a/apps/sccny/package.json
+++ b/apps/sccny/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "db:seed": "tsx prisma/seed.ts",
     "postinstall": "prisma generate && node -e \"require('fs').writeFileSync('src/generated/prisma/index.ts', '/* Re-export from client */\\nexport * from \\'./client\\'\\n')\""
   },
   "dependencies": {
@@ -37,7 +38,11 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
+    "tsx": "^4.19.0",
     "typescript": "^5"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
   },
   "browserslist": "> 1%"
 }

--- a/apps/sccny/prisma/schema.prisma
+++ b/apps/sccny/prisma/schema.prisma
@@ -55,3 +55,69 @@ enum NewsStatus {
   PUBLISHED
   ARCHIVED
 }
+
+model Role {
+  id          String           @id @default(cuid())
+  name        String           @unique
+  description String?
+  isSystem    Boolean          @default(false)
+  permissions RolePermission[]
+  users       UserRole[]
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+
+  @@map("roles")
+}
+
+model UserRole {
+  id         String   @id @default(cuid())
+  userId     String
+  roleId     String
+  role       Role     @relation(fields: [roleId], references: [id], onDelete: Cascade)
+  assignedBy String?
+  assignedAt DateTime @default(now())
+
+  @@unique([userId, roleId])
+  @@map("user_roles")
+}
+
+model Permission {
+  id          String           @id @default(cuid())
+  key         String           @unique
+  name        String
+  description String?
+  resource    String
+  action      String
+  roles       RolePermission[]
+
+  @@map("permissions")
+}
+
+model RolePermission {
+  roleId       String
+  permissionId String
+  role         Role       @relation(fields: [roleId], references: [id], onDelete: Cascade)
+  permission   Permission @relation(fields: [permissionId], references: [id], onDelete: Cascade)
+
+  @@id([roleId, permissionId])
+  @@map("role_permissions")
+}
+
+model AuditLog {
+  id           String   @id @default(cuid())
+  userId       String
+  userName     String
+  action       String
+  resourceType String
+  resourceId   String?
+  oldValues    Json?
+  newValues    Json?
+  ipAddress    String?
+  userAgent    String?
+  createdAt    DateTime @default(now())
+
+  @@index([userId])
+  @@index([resourceType])
+  @@index([createdAt])
+  @@map("audit_logs")
+}

--- a/apps/sccny/prisma/seed.ts
+++ b/apps/sccny/prisma/seed.ts
@@ -1,0 +1,183 @@
+import { PrismaClient } from "../src/generated/prisma";
+import { PrismaPg } from "@prisma/adapter-pg";
+import "dotenv/config";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+});
+
+const prisma = new PrismaClient({ adapter });
+
+const permissions = [
+  // Sermons
+  { key: "sermons.view", name: "View Sermons", resource: "sermons", action: "view" },
+  { key: "sermons.create", name: "Create Sermons", resource: "sermons", action: "create" },
+  { key: "sermons.edit", name: "Edit Sermons", resource: "sermons", action: "edit" },
+  { key: "sermons.delete", name: "Delete Sermons", resource: "sermons", action: "delete" },
+  { key: "sermons.sync", name: "Sync Sermons", resource: "sermons", action: "sync" },
+  // News
+  { key: "news.view", name: "View News", resource: "news", action: "view" },
+  { key: "news.create", name: "Create News", resource: "news", action: "create" },
+  { key: "news.edit", name: "Edit News", resource: "news", action: "edit" },
+  { key: "news.delete", name: "Delete News", resource: "news", action: "delete" },
+  // Members
+  { key: "members.view", name: "View Members", resource: "members", action: "view" },
+  { key: "members.create", name: "Create Members", resource: "members", action: "create" },
+  { key: "members.edit", name: "Edit Members", resource: "members", action: "edit" },
+  { key: "members.approve", name: "Approve Members", resource: "members", action: "approve" },
+  { key: "members.deactivate", name: "Deactivate Members", resource: "members", action: "deactivate" },
+  { key: "members.export", name: "Export Members", resource: "members", action: "export" },
+  { key: "members.import", name: "Import Members", resource: "members", action: "import" },
+  // Events
+  { key: "events.view", name: "View Events", resource: "events", action: "view" },
+  { key: "events.create", name: "Create Events", resource: "events", action: "create" },
+  { key: "events.edit", name: "Edit Events", resource: "events", action: "edit" },
+  { key: "events.delete", name: "Delete Events", resource: "events", action: "delete" },
+  { key: "events.registrations", name: "Manage Event Registrations", resource: "events", action: "registrations" },
+  // Announcements
+  { key: "announcements.view", name: "View Announcements", resource: "announcements", action: "view" },
+  { key: "announcements.create", name: "Create Announcements", resource: "announcements", action: "create" },
+  { key: "announcements.edit", name: "Edit Announcements", resource: "announcements", action: "edit" },
+  { key: "announcements.delete", name: "Delete Announcements", resource: "announcements", action: "delete" },
+  // Content
+  { key: "content.view", name: "View Content", resource: "content", action: "view" },
+  { key: "content.edit", name: "Edit Content", resource: "content", action: "edit" },
+  { key: "content.publish", name: "Publish Content", resource: "content", action: "publish" },
+  // Media
+  { key: "media.upload", name: "Upload Media", resource: "media", action: "upload" },
+  { key: "media.delete", name: "Delete Media", resource: "media", action: "delete" },
+  // Users
+  { key: "users.view", name: "View Users", resource: "users", action: "view" },
+  { key: "users.edit", name: "Edit Users", resource: "users", action: "edit" },
+  { key: "users.invite", name: "Invite Users", resource: "users", action: "invite" },
+  { key: "users.disable", name: "Disable Users", resource: "users", action: "disable" },
+  { key: "users.roles", name: "Manage User Roles", resource: "users", action: "roles" },
+  // Roles
+  { key: "roles.view", name: "View Roles", resource: "roles", action: "view" },
+  { key: "roles.create", name: "Create Roles", resource: "roles", action: "create" },
+  { key: "roles.edit", name: "Edit Roles", resource: "roles", action: "edit" },
+  { key: "roles.delete", name: "Delete Roles", resource: "roles", action: "delete" },
+  { key: "roles.assign", name: "Assign Roles", resource: "roles", action: "assign" },
+  // Audit
+  { key: "audit.view", name: "View Audit Log", resource: "audit", action: "view" },
+  { key: "audit.export", name: "Export Audit Log", resource: "audit", action: "export" },
+  // Tools
+  { key: "tools.translation.operate", name: "Operate Live Translation", resource: "tools", action: "translation.operate" },
+  { key: "tools.ppt.generate", name: "Generate PPT", resource: "tools", action: "ppt.generate" },
+];
+
+interface RoleDefinition {
+  name: string;
+  description: string;
+  isSystem: boolean;
+  permissionKeys: string[];
+}
+
+const allPermissionKeys = permissions.map((p) => p.key);
+
+const roles: RoleDefinition[] = [
+  {
+    name: "SUPER_ADMIN",
+    description: "Full access to all features",
+    isSystem: true,
+    permissionKeys: allPermissionKeys,
+  },
+  {
+    name: "ADMIN",
+    description: "Full access except user and role management",
+    isSystem: true,
+    permissionKeys: allPermissionKeys.filter(
+      (k) => !k.startsWith("users.") && !k.startsWith("roles.")
+    ),
+  },
+  {
+    name: "PASTOR",
+    description: "Sermons, events, announcements, and member view",
+    isSystem: true,
+    permissionKeys: [
+      "sermons.view", "sermons.create", "sermons.edit",
+      "events.view", "events.create", "events.edit", "events.registrations",
+      "announcements.view", "announcements.create", "announcements.edit",
+      "members.view",
+      "news.view",
+      "audit.view",
+    ],
+  },
+  {
+    name: "DEACON",
+    description: "Events, announcements, and member view",
+    isSystem: true,
+    permissionKeys: [
+      "events.view", "events.create", "events.edit", "events.registrations",
+      "announcements.view", "announcements.create", "announcements.edit",
+      "members.view",
+      "news.view",
+      "audit.view",
+    ],
+  },
+  {
+    name: "MEDIA_TEAM",
+    description: "Sermons, content, and media upload",
+    isSystem: true,
+    permissionKeys: [
+      "sermons.view", "sermons.create", "sermons.edit", "sermons.sync",
+      "content.view", "content.edit", "content.publish",
+      "media.upload", "media.delete",
+      "news.view",
+    ],
+  },
+  {
+    name: "MEMBER",
+    description: "Member corner access only",
+    isSystem: true,
+    permissionKeys: [
+      "members.view",
+    ],
+  },
+];
+
+async function main() {
+  console.log("Seeding permissions...");
+  for (const perm of permissions) {
+    await prisma.permission.upsert({
+      where: { key: perm.key },
+      update: { name: perm.name, resource: perm.resource, action: perm.action },
+      create: perm,
+    });
+  }
+  console.log(`Seeded ${permissions.length} permissions.`);
+
+  console.log("Seeding roles...");
+  for (const roleDef of roles) {
+    const role = await prisma.role.upsert({
+      where: { name: roleDef.name },
+      update: { description: roleDef.description, isSystem: roleDef.isSystem },
+      create: { name: roleDef.name, description: roleDef.description, isSystem: roleDef.isSystem },
+    });
+
+    // Get permission IDs for this role
+    const perms = await prisma.permission.findMany({
+      where: { key: { in: roleDef.permissionKeys } },
+      select: { id: true },
+    });
+
+    // Clear existing role permissions and re-create
+    await prisma.rolePermission.deleteMany({ where: { roleId: role.id } });
+    await prisma.rolePermission.createMany({
+      data: perms.map((p) => ({ roleId: role.id, permissionId: p.id })),
+    });
+
+    console.log(`  Role "${roleDef.name}" with ${perms.length} permissions.`);
+  }
+
+  console.log("Seed complete.");
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/sccny/src/app/[locale]/admin/audit-log/page.tsx
+++ b/apps/sccny/src/app/[locale]/admin/audit-log/page.tsx
@@ -1,0 +1,13 @@
+import { getTranslations } from "next-intl/server";
+import AuditLogViewer from "@/components/admin/AuditLogViewer";
+
+export default async function AuditLogPage() {
+  const t = await getTranslations("AuditLog");
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-foreground">{t("title")}</h1>
+      <AuditLogViewer />
+    </div>
+  );
+}

--- a/apps/sccny/src/app/[locale]/admin/layout.tsx
+++ b/apps/sccny/src/app/[locale]/admin/layout.tsx
@@ -1,0 +1,28 @@
+import { redirect } from "next/navigation";
+import { stackServerApp } from "@/stack/server";
+import { getUserPermissions } from "@/lib/permissions";
+import AdminShell from "@/components/admin/AdminShell";
+import PermissionsProvider from "@/components/admin/PermissionsProvider";
+
+export default async function AdminLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const user = await stackServerApp.getUser();
+
+  if (!user) {
+    redirect(`/${locale}/handler/sign-in?after_auth_return_to=/${locale}/admin`);
+  }
+
+  const permissions = await getUserPermissions(user.id);
+
+  return (
+    <PermissionsProvider permissions={permissions}>
+      <AdminShell>{children}</AdminShell>
+    </PermissionsProvider>
+  );
+}

--- a/apps/sccny/src/app/[locale]/admin/page.tsx
+++ b/apps/sccny/src/app/[locale]/admin/page.tsx
@@ -1,0 +1,89 @@
+import { getTranslations } from "next-intl/server";
+import { prisma } from "@/lib/db";
+import { Card, CardContent, CardHeader, CardTitle } from "dark-blue";
+import StatusBadge from "@/components/admin/StatusBadge";
+import { format } from "date-fns";
+
+export default async function AdminDashboard() {
+  const t = await getTranslations("Admin");
+
+  const [sermonCount, newsCount, recentLogs] = await Promise.all([
+    prisma.sermon.count(),
+    prisma.news.count(),
+    prisma.auditLog.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 10,
+    }),
+  ]);
+
+  const stats = [
+    { label: t("dashboard.sermons"), value: sermonCount },
+    { label: t("dashboard.news"), value: newsCount },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-foreground">
+        {t("dashboard.title")}
+      </h1>
+
+      {/* Stats cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {stats.map((stat) => (
+          <Card key={stat.label}>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                {stat.label}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold text-foreground">
+                {stat.value}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Recent activity */}
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("dashboard.recentActivity")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {recentLogs.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {t("dashboard.noActivity")}
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {recentLogs.map((log) => (
+                <div
+                  key={log.id}
+                  className="flex items-center justify-between py-2 border-b border-border last:border-0"
+                >
+                  <div className="flex items-center gap-3">
+                    <StatusBadge status={log.action} />
+                    <div>
+                      <span className="text-sm font-medium text-foreground">
+                        {log.userName}
+                      </span>
+                      <span className="text-sm text-muted-foreground">
+                        {" "}
+                        {log.action.toLowerCase()} {log.resourceType}
+                        {log.resourceId && ` #${log.resourceId.slice(0, 8)}`}
+                      </span>
+                    </div>
+                  </div>
+                  <span className="text-xs text-muted-foreground">
+                    {format(log.createdAt, "MMM d, HH:mm")}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/sccny/src/app/[locale]/admin/roles/[id]/page.tsx
+++ b/apps/sccny/src/app/[locale]/admin/roles/[id]/page.tsx
@@ -1,0 +1,40 @@
+import { getTranslations } from "next-intl/server";
+import { prisma } from "@/lib/db";
+import { notFound } from "next/navigation";
+import RoleDetail from "@/components/admin/RoleDetail";
+
+export default async function RoleDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string; locale: string }>;
+}) {
+  const { id } = await params;
+  const t = await getTranslations("RoleManagement");
+
+  const role = await prisma.role.findUnique({
+    where: { id },
+    include: {
+      permissions: {
+        include: { permission: true },
+      },
+      users: true,
+    },
+  });
+
+  if (!role) {
+    notFound();
+  }
+
+  const allPermissions = await prisma.permission.findMany({
+    orderBy: [{ resource: "asc" }, { action: "asc" }],
+  });
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-foreground">
+        {t("editRole")}: {role.name}
+      </h1>
+      <RoleDetail role={role} allPermissions={allPermissions} />
+    </div>
+  );
+}

--- a/apps/sccny/src/app/[locale]/admin/roles/page.tsx
+++ b/apps/sccny/src/app/[locale]/admin/roles/page.tsx
@@ -1,0 +1,25 @@
+import { getTranslations } from "next-intl/server";
+import { prisma } from "@/lib/db";
+import RoleTable from "@/components/admin/RoleTable";
+
+export default async function RolesPage() {
+  const t = await getTranslations("RoleManagement");
+
+  const roles = await prisma.role.findMany({
+    include: {
+      _count: {
+        select: { users: true, permissions: true },
+      },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-foreground">{t("title")}</h1>
+      </div>
+      <RoleTable roles={roles} />
+    </div>
+  );
+}

--- a/apps/sccny/src/app/api/admin/audit-log/export/route.ts
+++ b/apps/sccny/src/app/api/admin/audit-log/export/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getAdminUser, unauthorizedResponse, forbiddenResponse } from "@/lib/admin-auth";
+import { requirePermission, PermissionError } from "@/lib/permissions";
+import { GetAuditLogQuerySchema } from "@/lib/admin-validations";
+import { logAction } from "@/lib/audit";
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    await requirePermission(user.id, "audit.export");
+
+    const { searchParams } = new URL(request.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+    const validated = GetAuditLogQuerySchema.parse(queryParams);
+
+    const { userId, action, resourceType, dateFrom, dateTo, sortOrder } = validated;
+
+    const where = {
+      ...(userId && { userId }),
+      ...(action && { action }),
+      ...(resourceType && { resourceType }),
+      ...((dateFrom || dateTo) && {
+        createdAt: {
+          ...(dateFrom && { gte: new Date(dateFrom) }),
+          ...(dateTo && { lte: new Date(dateTo) }),
+        },
+      }),
+    };
+
+    const logs = await prisma.auditLog.findMany({
+      where,
+      orderBy: { createdAt: sortOrder },
+      take: 10000,
+    });
+
+    // Build CSV
+    const headers = ["ID", "User", "Action", "Resource Type", "Resource ID", "Created At"];
+    const rows = logs.map((log) =>
+      [
+        log.id,
+        log.userName,
+        log.action,
+        log.resourceType,
+        log.resourceId || "",
+        log.createdAt.toISOString(),
+      ]
+        .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+        .join(",")
+    );
+    const csv = [headers.join(","), ...rows].join("\n");
+
+    await logAction({
+      userId: user.id,
+      userName: user.displayName || user.primaryEmail || "Unknown",
+      action: "EXPORT",
+      resourceType: "audit_log",
+    });
+
+    return new NextResponse(csv, {
+      headers: {
+        "Content-Type": "text/csv",
+        "Content-Disposition": `attachment; filename="audit-log-${new Date().toISOString().slice(0, 10)}.csv"`,
+      },
+    });
+  } catch (error) {
+    if (error instanceof PermissionError) return forbiddenResponse();
+    console.error("Error exporting audit logs:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/app/api/admin/audit-log/route.ts
+++ b/apps/sccny/src/app/api/admin/audit-log/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getAdminUser, unauthorizedResponse, forbiddenResponse } from "@/lib/admin-auth";
+import { requirePermission, PermissionError } from "@/lib/permissions";
+import { GetAuditLogQuerySchema } from "@/lib/admin-validations";
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    await requirePermission(user.id, "audit.view");
+
+    const { searchParams } = new URL(request.url);
+    const queryParams = Object.fromEntries(searchParams.entries());
+    const validated = GetAuditLogQuerySchema.parse(queryParams);
+
+    const { page, limit, userId, action, resourceType, dateFrom, dateTo, sortOrder } = validated;
+    const skip = (page - 1) * limit;
+
+    const where = {
+      ...(userId && { userId }),
+      ...(action && { action }),
+      ...(resourceType && { resourceType }),
+      ...((dateFrom || dateTo) && {
+        createdAt: {
+          ...(dateFrom && { gte: new Date(dateFrom) }),
+          ...(dateTo && { lte: new Date(dateTo) }),
+        },
+      }),
+    };
+
+    const [logs, total] = await Promise.all([
+      prisma.auditLog.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { createdAt: sortOrder },
+      }),
+      prisma.auditLog.count({ where }),
+    ]);
+
+    return NextResponse.json({
+      data: logs,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    });
+  } catch (error) {
+    if (error instanceof PermissionError) return forbiddenResponse();
+    console.error("Error fetching audit logs:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/app/api/admin/permissions/mine/route.ts
+++ b/apps/sccny/src/app/api/admin/permissions/mine/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { getAdminUser, unauthorizedResponse } from "@/lib/admin-auth";
+import { getUserPermissions } from "@/lib/permissions";
+
+export async function GET() {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    const permissions = await getUserPermissions(user.id);
+
+    return NextResponse.json({ data: permissions });
+  } catch (error) {
+    console.error("Error fetching user permissions:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/app/api/admin/permissions/route.ts
+++ b/apps/sccny/src/app/api/admin/permissions/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getAdminUser, unauthorizedResponse, forbiddenResponse } from "@/lib/admin-auth";
+import { requirePermission, PermissionError } from "@/lib/permissions";
+
+export async function GET() {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    await requirePermission(user.id, "roles.view");
+
+    const permissions = await prisma.permission.findMany({
+      orderBy: [{ resource: "asc" }, { action: "asc" }],
+    });
+
+    // Group by resource
+    const grouped = permissions.reduce(
+      (acc, perm) => {
+        if (!acc[perm.resource]) acc[perm.resource] = [];
+        acc[perm.resource].push(perm);
+        return acc;
+      },
+      {} as Record<string, typeof permissions>
+    );
+
+    return NextResponse.json({ data: grouped });
+  } catch (error) {
+    if (error instanceof PermissionError) return forbiddenResponse();
+    console.error("Error fetching permissions:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/app/api/admin/roles/[id]/permissions/route.ts
+++ b/apps/sccny/src/app/api/admin/roles/[id]/permissions/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getAdminUser, unauthorizedResponse, forbiddenResponse } from "@/lib/admin-auth";
+import { requirePermission, PermissionError } from "@/lib/permissions";
+import { RolePermissionsUpdateSchema } from "@/lib/admin-validations";
+import { logAction } from "@/lib/audit";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    await requirePermission(user.id, "roles.edit");
+
+    const { id } = await params;
+    const role = await prisma.role.findUnique({
+      where: { id },
+      include: { permissions: true },
+    });
+    if (!role) {
+      return NextResponse.json({ error: "Role not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { permissionIds } = RolePermissionsUpdateSchema.parse(body);
+
+    const oldPermissionIds = role.permissions.map((rp) => rp.permissionId);
+
+    // Replace all permissions
+    await prisma.$transaction([
+      prisma.rolePermission.deleteMany({ where: { roleId: id } }),
+      prisma.rolePermission.createMany({
+        data: permissionIds.map((permissionId: string) => ({
+          roleId: id,
+          permissionId,
+        })),
+      }),
+    ]);
+
+    await logAction({
+      userId: user.id,
+      userName: user.displayName || user.primaryEmail || "Unknown",
+      action: "UPDATE",
+      resourceType: "role_permissions",
+      resourceId: id,
+      oldValues: { permissionIds: oldPermissionIds },
+      newValues: { permissionIds },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof PermissionError) return forbiddenResponse();
+    if (error instanceof Error && error.name === "ZodError") {
+      return NextResponse.json(
+        { error: "Validation failed", details: (error as unknown as { errors: unknown }).errors },
+        { status: 400 }
+      );
+    }
+    console.error("Error updating role permissions:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/app/api/admin/roles/[id]/route.ts
+++ b/apps/sccny/src/app/api/admin/roles/[id]/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getAdminUser, unauthorizedResponse, forbiddenResponse } from "@/lib/admin-auth";
+import { requirePermission, PermissionError } from "@/lib/permissions";
+import { RoleUpdateSchema } from "@/lib/admin-validations";
+import { logAction } from "@/lib/audit";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    await requirePermission(user.id, "roles.view");
+
+    const { id } = await params;
+    const role = await prisma.role.findUnique({
+      where: { id },
+      include: {
+        permissions: { include: { permission: true } },
+        users: true,
+      },
+    });
+
+    if (!role) {
+      return NextResponse.json({ error: "Role not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ data: role });
+  } catch (error) {
+    if (error instanceof PermissionError) return forbiddenResponse();
+    console.error("Error fetching role:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    await requirePermission(user.id, "roles.edit");
+
+    const { id } = await params;
+    const existing = await prisma.role.findUnique({ where: { id } });
+    if (!existing) {
+      return NextResponse.json({ error: "Role not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const validated = RoleUpdateSchema.parse(body);
+
+    const role = await prisma.role.update({
+      where: { id },
+      data: validated,
+    });
+
+    await logAction({
+      userId: user.id,
+      userName: user.displayName || user.primaryEmail || "Unknown",
+      action: "UPDATE",
+      resourceType: "role",
+      resourceId: role.id,
+      oldValues: { name: existing.name, description: existing.description },
+      newValues: validated as Record<string, unknown>,
+    });
+
+    return NextResponse.json({ data: role });
+  } catch (error) {
+    if (error instanceof PermissionError) return forbiddenResponse();
+    if (error instanceof Error && error.name === "ZodError") {
+      return NextResponse.json(
+        { error: "Validation failed", details: (error as unknown as { errors: unknown }).errors },
+        { status: 400 }
+      );
+    }
+    console.error("Error updating role:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    await requirePermission(user.id, "roles.delete");
+
+    const { id } = await params;
+    const role = await prisma.role.findUnique({ where: { id } });
+    if (!role) {
+      return NextResponse.json({ error: "Role not found" }, { status: 404 });
+    }
+
+    if (role.isSystem) {
+      return NextResponse.json(
+        { error: "Cannot delete system roles" },
+        { status: 400 }
+      );
+    }
+
+    await prisma.role.delete({ where: { id } });
+
+    await logAction({
+      userId: user.id,
+      userName: user.displayName || user.primaryEmail || "Unknown",
+      action: "DELETE",
+      resourceType: "role",
+      resourceId: id,
+      oldValues: { name: role.name, description: role.description },
+    });
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    if (error instanceof PermissionError) return forbiddenResponse();
+    console.error("Error deleting role:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/app/api/admin/roles/[id]/users/[userId]/route.ts
+++ b/apps/sccny/src/app/api/admin/roles/[id]/users/[userId]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getAdminUser, unauthorizedResponse, forbiddenResponse } from "@/lib/admin-auth";
+import { requirePermission, PermissionError } from "@/lib/permissions";
+import { logAction } from "@/lib/audit";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; userId: string }> }
+) {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    await requirePermission(user.id, "roles.assign");
+
+    const { id, userId } = await params;
+
+    const userRole = await prisma.userRole.findUnique({
+      where: { userId_roleId: { userId, roleId: id } },
+    });
+
+    if (!userRole) {
+      return NextResponse.json({ error: "User role not found" }, { status: 404 });
+    }
+
+    await prisma.userRole.delete({
+      where: { userId_roleId: { userId, roleId: id } },
+    });
+
+    await logAction({
+      userId: user.id,
+      userName: user.displayName || user.primaryEmail || "Unknown",
+      action: "DELETE",
+      resourceType: "user_role",
+      resourceId: userRole.id,
+      oldValues: { userId, roleId: id },
+    });
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    if (error instanceof PermissionError) return forbiddenResponse();
+    console.error("Error removing user from role:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/app/api/admin/roles/[id]/users/route.ts
+++ b/apps/sccny/src/app/api/admin/roles/[id]/users/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getAdminUser, unauthorizedResponse, forbiddenResponse } from "@/lib/admin-auth";
+import { requirePermission, PermissionError } from "@/lib/permissions";
+import { RoleUserAssignSchema } from "@/lib/admin-validations";
+import { logAction } from "@/lib/audit";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    await requirePermission(user.id, "roles.assign");
+
+    const { id } = await params;
+    const role = await prisma.role.findUnique({ where: { id } });
+    if (!role) {
+      return NextResponse.json({ error: "Role not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { userId } = RoleUserAssignSchema.parse(body);
+
+    const userRole = await prisma.userRole.create({
+      data: {
+        userId,
+        roleId: id,
+        assignedBy: user.id,
+      },
+    });
+
+    await logAction({
+      userId: user.id,
+      userName: user.displayName || user.primaryEmail || "Unknown",
+      action: "CREATE",
+      resourceType: "user_role",
+      resourceId: userRole.id,
+      newValues: { userId, roleId: id, roleName: role.name },
+    });
+
+    return NextResponse.json(userRole, { status: 201 });
+  } catch (error) {
+    if (error instanceof PermissionError) return forbiddenResponse();
+    if (error instanceof Error && error.name === "ZodError") {
+      return NextResponse.json(
+        { error: "Validation failed", details: (error as unknown as { errors: unknown }).errors },
+        { status: 400 }
+      );
+    }
+    console.error("Error assigning user to role:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/app/api/admin/roles/route.ts
+++ b/apps/sccny/src/app/api/admin/roles/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getAdminUser, unauthorizedResponse, forbiddenResponse } from "@/lib/admin-auth";
+import { requirePermission, PermissionError } from "@/lib/permissions";
+import { RoleCreateSchema } from "@/lib/admin-validations";
+import { logAction } from "@/lib/audit";
+
+export async function GET() {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    await requirePermission(user.id, "roles.view");
+
+    const roles = await prisma.role.findMany({
+      include: {
+        _count: {
+          select: { users: true, permissions: true },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return NextResponse.json({ data: roles });
+  } catch (error) {
+    if (error instanceof PermissionError) return forbiddenResponse();
+    console.error("Error fetching roles:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    await requirePermission(user.id, "roles.create");
+
+    const body = await request.json();
+    const validated = RoleCreateSchema.parse(body);
+
+    const role = await prisma.role.create({
+      data: {
+        name: validated.name,
+        description: validated.description,
+      },
+    });
+
+    await logAction({
+      userId: user.id,
+      userName: user.displayName || user.primaryEmail || "Unknown",
+      action: "CREATE",
+      resourceType: "role",
+      resourceId: role.id,
+      newValues: validated as Record<string, unknown>,
+    });
+
+    return NextResponse.json(role, { status: 201 });
+  } catch (error) {
+    if (error instanceof PermissionError) return forbiddenResponse();
+    if (error instanceof Error && error.name === "ZodError") {
+      return NextResponse.json(
+        { error: "Validation failed", details: (error as unknown as { errors: unknown }).errors },
+        { status: 400 }
+      );
+    }
+    console.error("Error creating role:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/components/admin/AdminShell.tsx
+++ b/apps/sccny/src/components/admin/AdminShell.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState, ReactNode } from "react";
+import AdminSidebar from "./AdminSidebar";
+import AdminTopBar from "./AdminTopBar";
+
+interface AdminShellProps {
+  children: ReactNode;
+}
+
+export default function AdminShell({ children }: AdminShellProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-background">
+      <AdminSidebar
+        isOpen={sidebarOpen}
+        onClose={() => setSidebarOpen(false)}
+      />
+      <div className="flex flex-col flex-1 overflow-hidden">
+        <AdminTopBar onMenuToggle={() => setSidebarOpen(!sidebarOpen)} />
+        <main className="flex-1 overflow-y-auto p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/apps/sccny/src/components/admin/AdminSidebar.tsx
+++ b/apps/sccny/src/components/admin/AdminSidebar.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Link, usePathname } from "@/i18n/navigation";
+import { cn } from "@/lib/utils";
+import { usePermissions } from "@/lib/permissions-client";
+import { Button } from "dark-blue";
+
+interface SidebarItem {
+  key: string;
+  href: string;
+  icon: React.ReactNode;
+  permission?: string;
+}
+
+const sidebarItems: SidebarItem[] = [
+  {
+    key: "dashboard",
+    href: "/admin",
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+      </svg>
+    ),
+  },
+  {
+    key: "roles",
+    href: "/admin/roles",
+    permission: "roles.view",
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+      </svg>
+    ),
+  },
+  {
+    key: "auditLog",
+    href: "/admin/audit-log",
+    permission: "audit.view",
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+      </svg>
+    ),
+  },
+];
+
+interface AdminSidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function AdminSidebar({ isOpen, onClose }: AdminSidebarProps) {
+  const t = useTranslations("Admin");
+  const pathname = usePathname();
+  const { hasPermission } = usePermissions();
+
+  const visibleItems = sidebarItems.filter(
+    (item) => !item.permission || hasPermission(item.permission)
+  );
+
+  return (
+    <>
+      {/* Mobile overlay */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+          onClick={onClose}
+        />
+      )}
+
+      <aside
+        className={cn(
+          "fixed top-0 left-0 z-50 h-full w-64 bg-card border-r border-border transition-transform duration-200 lg:relative lg:translate-x-0",
+          isOpen ? "translate-x-0" : "-translate-x-full"
+        )}
+      >
+        <div className="flex items-center justify-between h-16 px-4 border-b border-border">
+          <span className="text-lg font-semibold text-foreground">
+            {t("title")}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="lg:hidden"
+            onClick={onClose}
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </Button>
+        </div>
+
+        <nav className="p-4 space-y-1">
+          {visibleItems.map((item) => {
+            const isActive =
+              item.href === "/admin"
+                ? pathname === "/admin"
+                : pathname.startsWith(item.href);
+
+            return (
+              <Link
+                key={item.key}
+                href={item.href}
+                onClick={onClose}
+                className={cn(
+                  "flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                )}
+              >
+                {item.icon}
+                {t(`sidebar.${item.key}`)}
+              </Link>
+            );
+          })}
+        </nav>
+      </aside>
+    </>
+  );
+}

--- a/apps/sccny/src/components/admin/AdminTopBar.tsx
+++ b/apps/sccny/src/components/admin/AdminTopBar.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useUser } from "@stackframe/stack";
+import { Button } from "dark-blue";
+import { Link } from "@/i18n/navigation";
+
+interface AdminTopBarProps {
+  onMenuToggle: () => void;
+}
+
+export default function AdminTopBar({ onMenuToggle }: AdminTopBarProps) {
+  const t = useTranslations("Admin");
+  const user = useUser();
+
+  return (
+    <header className="sticky top-0 z-30 flex items-center justify-between h-16 px-4 bg-card border-b border-border">
+      <div className="flex items-center gap-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="lg:hidden"
+          onClick={onMenuToggle}
+        >
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </Button>
+        <Link href="/" className="text-sm text-muted-foreground hover:text-foreground">
+          &larr; {t("backToSite")}
+        </Link>
+      </div>
+
+      <div className="flex items-center gap-3">
+        {user && (
+          <span className="text-sm text-muted-foreground">
+            {user.displayName || user.primaryEmail}
+          </span>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/apps/sccny/src/components/admin/AuditLogViewer.tsx
+++ b/apps/sccny/src/components/admin/AuditLogViewer.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { Card, CardContent, Button, Input, Select } from "dark-blue";
+import StatusBadge from "./StatusBadge";
+import { usePermissions } from "@/lib/permissions-client";
+import { format } from "date-fns";
+
+interface AuditLogEntry {
+  id: string;
+  userId: string;
+  userName: string;
+  action: string;
+  resourceType: string;
+  resourceId: string | null;
+  oldValues: Record<string, unknown> | null;
+  newValues: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+interface Pagination {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+export default function AuditLogViewer() {
+  const t = useTranslations("AuditLog");
+  const { hasPermission } = usePermissions();
+  const [logs, setLogs] = useState<AuditLogEntry[]>([]);
+  const [pagination, setPagination] = useState<Pagination>({
+    page: 1,
+    limit: 50,
+    total: 0,
+    totalPages: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  // Filters
+  const [actionFilter, setActionFilter] = useState("");
+  const [resourceFilter, setResourceFilter] = useState("");
+
+  const fetchLogs = useCallback(async (page: number) => {
+    setLoading(true);
+    const params = new URLSearchParams({ page: String(page), limit: "50" });
+    if (actionFilter) params.set("action", actionFilter);
+    if (resourceFilter) params.set("resourceType", resourceFilter);
+
+    const res = await fetch(`/api/admin/audit-log?${params}`);
+    if (res.ok) {
+      const data = await res.json();
+      setLogs(data.data);
+      setPagination(data.pagination);
+    }
+    setLoading(false);
+  }, [actionFilter, resourceFilter]);
+
+  useEffect(() => {
+    fetchLogs(1);
+  }, [fetchLogs]);
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3">
+        <Select
+          value={actionFilter}
+          onChange={(e) => setActionFilter(e.target.value)}
+          className="w-40"
+        >
+          <option value="">{t("allActions")}</option>
+          <option value="CREATE">CREATE</option>
+          <option value="UPDATE">UPDATE</option>
+          <option value="DELETE">DELETE</option>
+          <option value="LOGIN">LOGIN</option>
+          <option value="EXPORT">EXPORT</option>
+          <option value="SYNC">SYNC</option>
+        </Select>
+
+        <Input
+          placeholder={t("filterResource")}
+          value={resourceFilter}
+          onChange={(e) => setResourceFilter(e.target.value)}
+          className="w-40"
+        />
+
+        {hasPermission("audit.export") && (
+          <Button
+            variant="outline"
+            onClick={() => {
+              const params = new URLSearchParams();
+              if (actionFilter) params.set("action", actionFilter);
+              if (resourceFilter) params.set("resourceType", resourceFilter);
+              window.open(`/api/admin/audit-log/export?${params}`, "_blank");
+            }}
+          >
+            {t("export")}
+          </Button>
+        )}
+      </div>
+
+      {/* Table */}
+      <Card>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-8 text-center text-muted-foreground">
+              {t("loading")}
+            </div>
+          ) : logs.length === 0 ? (
+            <div className="p-8 text-center text-muted-foreground">
+              {t("noLogs")}
+            </div>
+          ) : (
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left p-4 text-sm font-medium text-muted-foreground">
+                    {t("time")}
+                  </th>
+                  <th className="text-left p-4 text-sm font-medium text-muted-foreground">
+                    {t("user")}
+                  </th>
+                  <th className="text-left p-4 text-sm font-medium text-muted-foreground">
+                    {t("action")}
+                  </th>
+                  <th className="text-left p-4 text-sm font-medium text-muted-foreground">
+                    {t("resource")}
+                  </th>
+                  <th className="text-left p-4 text-sm font-medium text-muted-foreground">
+                    {t("details")}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {logs.map((log) => (
+                  <>
+                    <tr
+                      key={log.id}
+                      className="border-b border-border last:border-0 cursor-pointer hover:bg-muted/50"
+                      onClick={() =>
+                        setExpandedId(expandedId === log.id ? null : log.id)
+                      }
+                    >
+                      <td className="p-4 text-sm text-muted-foreground">
+                        {format(new Date(log.createdAt), "MMM d, yyyy HH:mm")}
+                      </td>
+                      <td className="p-4 text-sm text-foreground">
+                        {log.userName}
+                      </td>
+                      <td className="p-4">
+                        <StatusBadge status={log.action} />
+                      </td>
+                      <td className="p-4 text-sm text-muted-foreground">
+                        {log.resourceType}
+                        {log.resourceId && (
+                          <span className="text-xs ml-1">
+                            #{log.resourceId.slice(0, 8)}
+                          </span>
+                        )}
+                      </td>
+                      <td className="p-4 text-sm text-muted-foreground">
+                        {expandedId === log.id ? "▼" : "▶"}
+                      </td>
+                    </tr>
+                    {expandedId === log.id && (
+                      <tr key={`${log.id}-detail`}>
+                        <td colSpan={5} className="p-4 bg-muted/30">
+                          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
+                            {log.oldValues && (
+                              <div>
+                                <p className="font-semibold text-foreground mb-1">
+                                  {t("oldValues")}
+                                </p>
+                                <pre className="bg-card p-2 rounded overflow-auto max-h-48">
+                                  {JSON.stringify(log.oldValues, null, 2)}
+                                </pre>
+                              </div>
+                            )}
+                            {log.newValues && (
+                              <div>
+                                <p className="font-semibold text-foreground mb-1">
+                                  {t("newValues")}
+                                </p>
+                                <pre className="bg-card p-2 rounded overflow-auto max-h-48">
+                                  {JSON.stringify(log.newValues, null, 2)}
+                                </pre>
+                              </div>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Pagination */}
+      {pagination.totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">
+            {t("page")} {pagination.page} / {pagination.totalPages} ({pagination.total} {t("total")})
+          </span>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={pagination.page <= 1}
+              onClick={() => fetchLogs(pagination.page - 1)}
+            >
+              {t("previous")}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={pagination.page >= pagination.totalPages}
+              onClick={() => fetchLogs(pagination.page + 1)}
+            >
+              {t("next")}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/sccny/src/components/admin/ConfirmDialog.tsx
+++ b/apps/sccny/src/components/admin/ConfirmDialog.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Button } from "dark-blue";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  destructive?: boolean;
+}
+
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  onConfirm,
+  onCancel,
+  destructive = false,
+}: ConfirmDialogProps) {
+  const t = useTranslations("Admin");
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/50" onClick={onCancel} />
+      <div className="relative bg-card rounded-lg border border-border shadow-lg p-6 w-full max-w-md mx-4">
+        <h3 className="text-lg font-semibold text-foreground">{title}</h3>
+        <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+        <div className="mt-4 flex justify-end gap-2">
+          <Button variant="outline" onClick={onCancel}>
+            {t("actions.cancel")}
+          </Button>
+          <Button
+            variant={destructive ? "destructive" : "default"}
+            onClick={onConfirm}
+          >
+            {confirmLabel || t("actions.confirm")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/sccny/src/components/admin/PermissionGate.tsx
+++ b/apps/sccny/src/components/admin/PermissionGate.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { ReactNode } from "react";
+import { usePermissions } from "@/lib/permissions-client";
+
+interface PermissionGateProps {
+  permission: string;
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+export default function PermissionGate({
+  permission,
+  children,
+  fallback = null,
+}: PermissionGateProps) {
+  const { hasPermission } = usePermissions();
+
+  if (!hasPermission(permission)) {
+    return <>{fallback}</>;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/sccny/src/components/admin/PermissionMatrix.tsx
+++ b/apps/sccny/src/components/admin/PermissionMatrix.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+interface Permission {
+  id: string;
+  key: string;
+  name: string;
+  description: string | null;
+  resource: string;
+  action: string;
+}
+
+interface PermissionMatrixProps {
+  allPermissions: Permission[];
+  selectedIds: Set<string>;
+  onToggle: (permissionId: string) => void;
+  disabled?: boolean;
+}
+
+export default function PermissionMatrix({
+  allPermissions,
+  selectedIds,
+  onToggle,
+  disabled = false,
+}: PermissionMatrixProps) {
+  const t = useTranslations("RoleManagement");
+
+  // Group permissions by resource
+  const grouped = allPermissions.reduce(
+    (acc, perm) => {
+      if (!acc[perm.resource]) acc[perm.resource] = [];
+      acc[perm.resource].push(perm);
+      return acc;
+    },
+    {} as Record<string, Permission[]>
+  );
+
+  return (
+    <div className="space-y-4">
+      {Object.entries(grouped).map(([resource, perms]) => (
+        <div key={resource}>
+          <h4 className="text-sm font-semibold text-foreground capitalize mb-2">
+            {resource}
+          </h4>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+            {perms.map((perm) => (
+              <label
+                key={perm.id}
+                className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(perm.id)}
+                  onChange={() => onToggle(perm.id)}
+                  disabled={disabled}
+                  className="rounded border-border"
+                />
+                <span>{perm.name}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      ))}
+      {allPermissions.length === 0 && (
+        <p className="text-sm text-muted-foreground">{t("noPermissions")}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/sccny/src/components/admin/PermissionsProvider.tsx
+++ b/apps/sccny/src/components/admin/PermissionsProvider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { ReactNode, useMemo } from "react";
+import { PermissionsContext } from "@/lib/permissions-client";
+
+interface PermissionsProviderProps {
+  permissions: string[];
+  children: ReactNode;
+}
+
+export default function PermissionsProvider({
+  permissions,
+  children,
+}: PermissionsProviderProps) {
+  const value = useMemo(
+    () => ({
+      permissions,
+      hasPermission: (key: string) => permissions.includes(key),
+    }),
+    [permissions]
+  );
+
+  return (
+    <PermissionsContext.Provider value={value}>
+      {children}
+    </PermissionsContext.Provider>
+  );
+}

--- a/apps/sccny/src/components/admin/RoleDetail.tsx
+++ b/apps/sccny/src/components/admin/RoleDetail.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/navigation";
+import { Button, Card, CardContent, CardHeader, CardTitle, Input, Label } from "dark-blue";
+import { usePermissions } from "@/lib/permissions-client";
+import PermissionMatrix from "./PermissionMatrix";
+
+interface Permission {
+  id: string;
+  key: string;
+  name: string;
+  description: string | null;
+  resource: string;
+  action: string;
+}
+
+interface Role {
+  id: string;
+  name: string;
+  description: string | null;
+  isSystem: boolean;
+  permissions: { permissionId: string; permission: Permission }[];
+  users: { id: string; userId: string; assignedAt: Date }[];
+}
+
+interface RoleDetailProps {
+  role: Role;
+  allPermissions: Permission[];
+}
+
+export default function RoleDetail({ role, allPermissions }: RoleDetailProps) {
+  const t = useTranslations("RoleManagement");
+  const router = useRouter();
+  const { hasPermission } = usePermissions();
+
+  const [name, setName] = useState(role.name);
+  const [description, setDescription] = useState(role.description || "");
+  const [selectedPermissionIds, setSelectedPermissionIds] = useState<Set<string>>(
+    new Set(role.permissions.map((rp) => rp.permissionId))
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSaveDetails() {
+    setSaving(true);
+    setError("");
+    const res = await fetch(`/api/admin/roles/${role.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, description }),
+    });
+    if (!res.ok) {
+      const data = await res.json();
+      setError(data.error || "Failed to update role");
+    }
+    setSaving(false);
+    router.refresh();
+  }
+
+  async function handleSavePermissions() {
+    setSaving(true);
+    setError("");
+    const res = await fetch(`/api/admin/roles/${role.id}/permissions`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        permissionIds: Array.from(selectedPermissionIds),
+      }),
+    });
+    if (!res.ok) {
+      const data = await res.json();
+      setError(data.error || "Failed to update permissions");
+    }
+    setSaving(false);
+    router.refresh();
+  }
+
+  function togglePermission(permId: string) {
+    setSelectedPermissionIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(permId)) {
+        next.delete(permId);
+      } else {
+        next.add(permId);
+      }
+      return next;
+    });
+  }
+
+  const canEdit = hasPermission("roles.edit");
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <p className="text-sm text-destructive">{error}</p>
+      )}
+
+      {/* Role details */}
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("details")}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label htmlFor="role-name">{t("name")}</Label>
+            <Input
+              id="role-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={!canEdit}
+            />
+          </div>
+          <div>
+            <Label htmlFor="role-desc">{t("description")}</Label>
+            <Input
+              id="role-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              disabled={!canEdit}
+            />
+          </div>
+          {canEdit && (
+            <Button onClick={handleSaveDetails} disabled={saving}>
+              {saving ? t("saving") : t("save")}
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Permission matrix */}
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("permissionsTitle")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <PermissionMatrix
+            allPermissions={allPermissions}
+            selectedIds={selectedPermissionIds}
+            onToggle={togglePermission}
+            disabled={!canEdit}
+          />
+          {canEdit && (
+            <div className="mt-4">
+              <Button onClick={handleSavePermissions} disabled={saving}>
+                {saving ? t("saving") : t("savePermissions")}
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Assigned users */}
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {t("assignedUsers")} ({role.users.length})
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {role.users.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t("noUsers")}</p>
+          ) : (
+            <div className="space-y-2">
+              {role.users.map((ur) => (
+                <div
+                  key={ur.id}
+                  className="flex items-center justify-between py-2 border-b border-border last:border-0"
+                >
+                  <span className="text-sm text-foreground">{ur.userId}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/sccny/src/components/admin/RoleFormDialog.tsx
+++ b/apps/sccny/src/components/admin/RoleFormDialog.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/navigation";
+import { Button, Input, Label } from "dark-blue";
+
+interface RoleFormDialogProps {
+  onClose: () => void;
+}
+
+export default function RoleFormDialog({ onClose }: RoleFormDialogProps) {
+  const t = useTranslations("RoleManagement");
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError("");
+
+    const res = await fetch("/api/admin/roles", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, description }),
+    });
+
+    if (res.ok) {
+      router.refresh();
+      onClose();
+    } else {
+      const data = await res.json();
+      setError(data.error || "Failed to create role");
+    }
+    setSubmitting(false);
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      <div className="relative bg-card rounded-lg border border-border shadow-lg p-6 w-full max-w-md mx-4">
+        <h3 className="text-lg font-semibold text-foreground mb-4">
+          {t("createRole")}
+        </h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="role-name">{t("name")}</Label>
+            <Input
+              id="role-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="role-desc">{t("description")}</Label>
+            <Input
+              id="role-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+          {error && (
+            <p className="text-sm text-destructive">{error}</p>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" type="button" onClick={onClose}>
+              {t("cancel")}
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? t("saving") : t("create")}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/sccny/src/components/admin/RoleTable.tsx
+++ b/apps/sccny/src/components/admin/RoleTable.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
+import { Card, CardContent, Badge, Button } from "dark-blue";
+import { usePermissions } from "@/lib/permissions-client";
+import { useState } from "react";
+import ConfirmDialog from "./ConfirmDialog";
+import { useRouter } from "@/i18n/navigation";
+import RoleFormDialog from "./RoleFormDialog";
+
+interface Role {
+  id: string;
+  name: string;
+  description: string | null;
+  isSystem: boolean;
+  _count: { users: number; permissions: number };
+}
+
+interface RoleTableProps {
+  roles: Role[];
+}
+
+export default function RoleTable({ roles }: RoleTableProps) {
+  const t = useTranslations("RoleManagement");
+  const { hasPermission } = usePermissions();
+  const router = useRouter();
+  const [deleteTarget, setDeleteTarget] = useState<Role | null>(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    const res = await fetch(`/api/admin/roles/${deleteTarget.id}`, {
+      method: "DELETE",
+    });
+    if (res.ok) {
+      router.refresh();
+    }
+    setDeleteTarget(null);
+  }
+
+  return (
+    <>
+      {hasPermission("roles.create") && (
+        <Button onClick={() => setShowCreateForm(true)}>
+          {t("createRole")}
+        </Button>
+      )}
+
+      <Card>
+        <CardContent className="p-0">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left p-4 text-sm font-medium text-muted-foreground">
+                  {t("name")}
+                </th>
+                <th className="text-left p-4 text-sm font-medium text-muted-foreground">
+                  {t("description")}
+                </th>
+                <th className="text-left p-4 text-sm font-medium text-muted-foreground">
+                  {t("permissions")}
+                </th>
+                <th className="text-left p-4 text-sm font-medium text-muted-foreground">
+                  {t("users")}
+                </th>
+                <th className="text-right p-4 text-sm font-medium text-muted-foreground">
+                  {t("actions")}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {roles.map((role) => (
+                <tr
+                  key={role.id}
+                  className="border-b border-border last:border-0"
+                >
+                  <td className="p-4">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-foreground">
+                        {role.name}
+                      </span>
+                      {role.isSystem && (
+                        <Badge variant="subtle">{t("system")}</Badge>
+                      )}
+                    </div>
+                  </td>
+                  <td className="p-4 text-sm text-muted-foreground">
+                    {role.description}
+                  </td>
+                  <td className="p-4 text-sm text-muted-foreground">
+                    {role._count.permissions}
+                  </td>
+                  <td className="p-4 text-sm text-muted-foreground">
+                    {role._count.users}
+                  </td>
+                  <td className="p-4 text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      {hasPermission("roles.edit") && (
+                        <Link href={`/admin/roles/${role.id}`}>
+                          <Button variant="outline" size="sm">
+                            {t("edit")}
+                          </Button>
+                        </Link>
+                      )}
+                      {hasPermission("roles.delete") && !role.isSystem && (
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => setDeleteTarget(role)}
+                        >
+                          {t("delete")}
+                        </Button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title={t("confirmDelete")}
+        description={t("confirmDeleteDescription", {
+          name: deleteTarget?.name || "",
+        })}
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+        destructive
+      />
+
+      {showCreateForm && (
+        <RoleFormDialog onClose={() => setShowCreateForm(false)} />
+      )}
+    </>
+  );
+}

--- a/apps/sccny/src/components/admin/StatusBadge.tsx
+++ b/apps/sccny/src/components/admin/StatusBadge.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Badge } from "dark-blue";
+import { cn } from "@/lib/utils";
+
+const statusStyles: Record<string, string> = {
+  ACTIVE: "bg-success/10 text-success border-success/20",
+  DRAFT: "bg-muted text-muted-foreground border-muted",
+  PUBLISHED: "bg-success/10 text-success border-success/20",
+  ARCHIVED: "bg-warning/10 text-warning border-warning/20",
+  CREATE: "bg-success/10 text-success border-success/20",
+  UPDATE: "bg-info/10 text-info border-info/20",
+  DELETE: "bg-destructive/10 text-destructive border-destructive/20",
+  LOGIN: "bg-primary/10 text-primary border-primary/20",
+  EXPORT: "bg-warning/10 text-warning border-warning/20",
+  SYNC: "bg-info/10 text-info border-info/20",
+};
+
+interface StatusBadgeProps {
+  status: string;
+  className?: string;
+}
+
+export default function StatusBadge({ status, className }: StatusBadgeProps) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(statusStyles[status] || "bg-muted text-muted-foreground", className)}
+    >
+      {status}
+    </Badge>
+  );
+}

--- a/apps/sccny/src/lib/admin-auth.ts
+++ b/apps/sccny/src/lib/admin-auth.ts
@@ -1,0 +1,17 @@
+import "server-only";
+import { stackServerApp } from "@/stack/server";
+import { NextResponse } from "next/server";
+
+export async function getAdminUser() {
+  const user = await stackServerApp.getUser();
+  if (!user) return null;
+  return user;
+}
+
+export function unauthorizedResponse() {
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+export function forbiddenResponse() {
+  return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+}

--- a/apps/sccny/src/lib/admin-validations.ts
+++ b/apps/sccny/src/lib/admin-validations.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+// Role schemas
+export const RoleCreateSchema = z.object({
+  name: z.string().min(1, "Name is required").max(50),
+  description: z.string().max(255).optional(),
+});
+
+export const RoleUpdateSchema = z.object({
+  name: z.string().min(1).max(50).optional(),
+  description: z.string().max(255).optional(),
+});
+
+export const RolePermissionsUpdateSchema = z.object({
+  permissionIds: z.array(z.string()),
+});
+
+export const RoleUserAssignSchema = z.object({
+  userId: z.string().min(1, "User ID is required"),
+});
+
+// Audit log query schema
+export const GetAuditLogQuerySchema = z.object({
+  page: z
+    .string()
+    .optional()
+    .default("1")
+    .transform((val) => parseInt(val)),
+  limit: z
+    .string()
+    .optional()
+    .default("50")
+    .transform((val) => Math.min(parseInt(val), 100)),
+  userId: z.string().optional(),
+  action: z.string().optional(),
+  resourceType: z.string().optional(),
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+  sortOrder: z.enum(["asc", "desc"]).optional().default("desc"),
+});
+
+export type RoleCreateType = z.infer<typeof RoleCreateSchema>;
+export type RoleUpdateType = z.infer<typeof RoleUpdateSchema>;
+export type GetAuditLogQueryType = z.infer<typeof GetAuditLogQuerySchema>;

--- a/apps/sccny/src/lib/audit.ts
+++ b/apps/sccny/src/lib/audit.ts
@@ -1,0 +1,35 @@
+import "server-only";
+import { prisma } from "@/lib/db";
+
+interface AuditLogInput {
+  userId: string;
+  userName: string;
+  action: "CREATE" | "UPDATE" | "DELETE" | "LOGIN" | "EXPORT" | "SYNC";
+  resourceType: string;
+  resourceId?: string;
+  oldValues?: Record<string, unknown>;
+  newValues?: Record<string, unknown>;
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+export async function logAction(input: AuditLogInput): Promise<void> {
+  try {
+    await prisma.auditLog.create({
+      data: {
+        userId: input.userId,
+        userName: input.userName,
+        action: input.action,
+        resourceType: input.resourceType,
+        resourceId: input.resourceId,
+        oldValues: input.oldValues as Record<string, string | number | boolean | null> | undefined,
+        newValues: input.newValues as Record<string, string | number | boolean | null> | undefined,
+        ipAddress: input.ipAddress,
+        userAgent: input.userAgent,
+      },
+    });
+  } catch (error) {
+    // Audit logging should not break the main operation
+    console.error("Failed to write audit log:", error);
+  }
+}

--- a/apps/sccny/src/lib/permissions-client.ts
+++ b/apps/sccny/src/lib/permissions-client.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+interface PermissionsContextValue {
+  permissions: string[];
+  hasPermission: (key: string) => boolean;
+}
+
+export const PermissionsContext = createContext<PermissionsContextValue>({
+  permissions: [],
+  hasPermission: () => false,
+});
+
+export function usePermissions() {
+  return useContext(PermissionsContext);
+}

--- a/apps/sccny/src/lib/permissions.ts
+++ b/apps/sccny/src/lib/permissions.ts
@@ -1,0 +1,58 @@
+import "server-only";
+import { prisma } from "@/lib/db";
+
+export async function getUserPermissions(userId: string): Promise<string[]> {
+  const userRoles = await prisma.userRole.findMany({
+    where: { userId },
+    include: {
+      role: {
+        include: {
+          permissions: {
+            include: { permission: true },
+          },
+        },
+      },
+    },
+  });
+
+  const permissionSet = new Set<string>();
+  for (const ur of userRoles) {
+    for (const rp of ur.role.permissions) {
+      permissionSet.add(rp.permission.key);
+    }
+  }
+
+  return Array.from(permissionSet);
+}
+
+export async function hasPermission(
+  userId: string,
+  permissionKey: string
+): Promise<boolean> {
+  const count = await prisma.rolePermission.count({
+    where: {
+      permission: { key: permissionKey },
+      role: {
+        users: { some: { userId } },
+      },
+    },
+  });
+  return count > 0;
+}
+
+export async function requirePermission(
+  userId: string,
+  permissionKey: string
+): Promise<void> {
+  const allowed = await hasPermission(userId, permissionKey);
+  if (!allowed) {
+    throw new PermissionError(`Missing permission: ${permissionKey}`);
+  }
+}
+
+export class PermissionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PermissionError";
+  }
+}

--- a/apps/sccny/src/messages/en.json
+++ b/apps/sccny/src/messages/en.json
@@ -314,5 +314,74 @@
       "resultTitle": "Bible Verse",
       "loading": "Loading..."
     }
+  },
+  "Admin": {
+    "title": "Admin Portal",
+    "backToSite": "Back to Site",
+    "sidebar": {
+      "dashboard": "Dashboard",
+      "roles": "Roles",
+      "auditLog": "Audit Log"
+    },
+    "dashboard": {
+      "title": "Dashboard",
+      "sermons": "Sermons",
+      "news": "News",
+      "recentActivity": "Recent Activity",
+      "noActivity": "No recent activity."
+    },
+    "actions": {
+      "save": "Save",
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "edit": "Edit",
+      "create": "Create",
+      "confirm": "Confirm"
+    }
+  },
+  "RoleManagement": {
+    "title": "Role Management",
+    "createRole": "Create Role",
+    "editRole": "Edit Role",
+    "name": "Name",
+    "description": "Description",
+    "permissions": "Permissions",
+    "users": "Users",
+    "actions": "Actions",
+    "system": "System",
+    "edit": "Edit",
+    "delete": "Delete",
+    "confirmDelete": "Delete Role",
+    "confirmDeleteDescription": "Are you sure you want to delete the role \"{name}\"? This action cannot be undone.",
+    "details": "Role Details",
+    "permissionsTitle": "Permissions",
+    "savePermissions": "Save Permissions",
+    "assignedUsers": "Assigned Users",
+    "noUsers": "No users assigned to this role.",
+    "noPermissions": "No permissions available. Run the seed script first.",
+    "save": "Save",
+    "saving": "Saving...",
+    "create": "Create",
+    "cancel": "Cancel"
+  },
+  "AuditLog": {
+    "title": "Audit Log",
+    "filterAction": "Filter by action",
+    "allActions": "All Actions",
+    "filterResource": "Resource type...",
+    "export": "Export CSV",
+    "loading": "Loading...",
+    "noLogs": "No audit log entries found.",
+    "time": "Time",
+    "user": "User",
+    "action": "Action",
+    "resource": "Resource",
+    "details": "Details",
+    "oldValues": "Previous Values",
+    "newValues": "New Values",
+    "page": "Page",
+    "total": "total",
+    "previous": "Previous",
+    "next": "Next"
   }
 }

--- a/apps/sccny/src/messages/zh.json
+++ b/apps/sccny/src/messages/zh.json
@@ -314,5 +314,74 @@
       "resultTitle": "圣经经文",
       "loading": "加载中..."
     }
+  },
+  "Admin": {
+    "title": "管理后台",
+    "backToSite": "返回网站",
+    "sidebar": {
+      "dashboard": "仪表盘",
+      "roles": "角色管理",
+      "auditLog": "审计日志"
+    },
+    "dashboard": {
+      "title": "仪表盘",
+      "sermons": "讲道",
+      "news": "新闻",
+      "recentActivity": "最近活动",
+      "noActivity": "暂无活动记录。"
+    },
+    "actions": {
+      "save": "保存",
+      "cancel": "取消",
+      "delete": "删除",
+      "edit": "编辑",
+      "create": "创建",
+      "confirm": "确认"
+    }
+  },
+  "RoleManagement": {
+    "title": "角色管理",
+    "createRole": "创建角色",
+    "editRole": "编辑角色",
+    "name": "名称",
+    "description": "描述",
+    "permissions": "权限",
+    "users": "用户",
+    "actions": "操作",
+    "system": "系统",
+    "edit": "编辑",
+    "delete": "删除",
+    "confirmDelete": "删除角色",
+    "confirmDeleteDescription": "确定要删除角色 \"{name}\" 吗？此操作不可撤销。",
+    "details": "角色详情",
+    "permissionsTitle": "权限设置",
+    "savePermissions": "保存权限",
+    "assignedUsers": "已分配用户",
+    "noUsers": "此角色暂无已分配的用户。",
+    "noPermissions": "暂无可用权限，请先运行种子脚本。",
+    "save": "保存",
+    "saving": "保存中...",
+    "create": "创建",
+    "cancel": "取消"
+  },
+  "AuditLog": {
+    "title": "审计日志",
+    "filterAction": "按操作筛选",
+    "allActions": "所有操作",
+    "filterResource": "资源类型...",
+    "export": "导出 CSV",
+    "loading": "加载中...",
+    "noLogs": "未找到审计日志记录。",
+    "time": "时间",
+    "user": "用户",
+    "action": "操作",
+    "resource": "资源",
+    "details": "详情",
+    "oldValues": "旧值",
+    "newValues": "新值",
+    "page": "页",
+    "total": "总计",
+    "previous": "上一页",
+    "next": "下一页"
   }
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -27,10 +27,10 @@ These are prerequisites for all admin features. Build first.
 
 | Status | Feature | Plan | Dependencies |
 |--------|---------|------|--------------|
-| :clipboard: | Admin Portal Infrastructure | [admin-infrastructure.md](./features/admin-infrastructure.md) | — |
-| :clipboard: | Role Management | [role-management.md](./features/role-management.md) | Admin Infrastructure |
-| :clipboard: | Permission Management | [permission-management.md](./features/permission-management.md) | Role Management |
-| :clipboard: | Audit Log | [audit-log.md](./features/audit-log.md) | Admin Infrastructure |
+| :white_check_mark: | Admin Portal Infrastructure | [admin-infrastructure.md](./features/admin-infrastructure.md) | — |
+| :white_check_mark: | Role Management | [role-management.md](./features/role-management.md) | Admin Infrastructure |
+| :white_check_mark: | Permission Management | [permission-management.md](./features/permission-management.md) | Role Management |
+| :white_check_mark: | Audit Log | [audit-log.md](./features/audit-log.md) | Admin Infrastructure |
 
 ## Phase 2: User & Member System
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.1.18
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -7510,8 +7513,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -7533,7 +7536,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7544,22 +7547,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7570,7 +7573,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
… audit log

Add the complete Phase 1 foundation for the admin portal:

- Admin layout shell with sidebar navigation, top bar, and auth-gated access
- Role management with CRUD operations and system roles (SUPER_ADMIN, ADMIN, PASTOR, DEACON, MEDIA_TEAM, MEMBER)
- Permission system with 44 granular permissions across 11 resources
- Permission matrix UI for assigning permissions to roles
- Audit log with filterable viewer, expandable detail rows, and CSV export
- Prisma schema additions: Role, Permission, RolePermission, UserRole, AuditLog
- Seed script to populate default permissions and system roles
- Server-side permission utilities (hasPermission, requirePermission, getUserPermissions)
- Client-side usePermissions hook and PermissionGate component
- Full bilingual i18n support (en/zh) for all admin features
- 7 new API endpoints under /api/admin/ following existing patterns