### PR TITLE
feat: Add member-only community feed with Google Drive image support

### DIFF
--- a/apps/sccny/package.json
+++ b/apps/sccny/package.json
@@ -30,6 +30,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "tailwind-merge": "^3.5.0",
+    "googleapis": "^171.4.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/sccny/prisma/schema.prisma
+++ b/apps/sccny/prisma/schema.prisma
@@ -153,6 +153,7 @@ model Member {
   ministryAssignments String[]
   profilePhoto        String?
   prayerRequests      PrayerRequest[]
+  communityPosts      CommunityPost[]
   createdAt           DateTime            @default(now())
   updatedAt           DateTime            @updatedAt
 
@@ -426,6 +427,33 @@ enum OrderItemType {
   PRAYER
   OFFERING
   BENEDICTION
+}
+
+// ── Phase 5: System Configuration ──
+
+model SystemConfig {
+  key       String   @id
+  value     String
+  updatedAt DateTime @updatedAt
+
+  @@map("system_config")
+}
+
+// ── Phase 5: Community Feed ──
+
+model CommunityPost {
+  id          String   @id @default(cuid())
+  memberId    String
+  member      Member   @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  content     String
+  imageUrl    String?
+  imageFileId String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([memberId])
+  @@index([createdAt])
+  @@map("community_posts")
 }
 
 // ── Phase 4: Live Translation ──

--- a/apps/sccny/prisma/seed.ts
+++ b/apps/sccny/prisma/seed.ts
@@ -79,6 +79,8 @@ const permissions = [
   // Tools
   { key: "tools.translation.operate", name: "Operate Live Translation", resource: "tools", action: "translation.operate" },
   { key: "tools.ppt.generate", name: "Generate PPT (Tools)", resource: "tools", action: "ppt.generate" },
+  // Community
+  { key: "community.manage", name: "Manage Community Posts", resource: "community", action: "manage" },
 ];
 
 interface RoleDefinition {
@@ -188,6 +190,14 @@ async function main() {
 
     console.log(`  Role "${roleDef.name}" with ${perms.length} permissions.`);
   }
+
+  console.log("Seeding system config...");
+  await prisma.systemConfig.upsert({
+    where: { key: "post_max_length" },
+    update: {},
+    create: { key: "post_max_length", value: "150" },
+  });
+  console.log("  SystemConfig: post_max_length = 150");
 
   console.log("Seed complete.");
 }

--- a/apps/sccny/src/app/[locale]/my-account/community/page.tsx
+++ b/apps/sccny/src/app/[locale]/my-account/community/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/db";
+import { stackServerApp } from "@/stack/server";
+import CommunityFeed from "@/components/member-corner/CommunityFeed";
+import { getTranslations } from "next-intl/server";
+
+export default async function CommunityPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const user = await stackServerApp.getUser();
+  if (!user) return null;
+
+  const member = await prisma.member.findUnique({ where: { userId: user.id } });
+
+  if (!member || member.status !== "ACTIVE") {
+    redirect(`/${locale}/my-account`);
+  }
+
+  const config = await prisma.systemConfig.findUnique({ where: { key: "post_max_length" } });
+  const maxLength = config ? parseInt(config.value) : 150;
+
+  const t = await getTranslations("Community");
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-foreground">{t("title")}</h1>
+      <CommunityFeed currentMemberId={member.id} maxLength={maxLength} />
+    </div>
+  );
+}

--- a/apps/sccny/src/app/api/admin/community-posts/[id]/route.ts
+++ b/apps/sccny/src/app/api/admin/community-posts/[id]/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getAdminUser, unauthorizedResponse, forbiddenResponse } from "@/lib/admin-auth";
+import { requirePermission, PermissionError } from "@/lib/permissions";
+import { logAction } from "@/lib/audit";
+import { deleteFileFromDrive } from "@/lib/google-drive";
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    await requirePermission(user.id, "community.manage");
+
+    const { id } = await params;
+    const post = await prisma.communityPost.findUnique({
+      where: { id },
+      include: { member: { select: { name: true } } },
+    });
+
+    if (!post) return NextResponse.json({ error: "Post not found" }, { status: 404 });
+
+    await prisma.communityPost.delete({ where: { id } });
+
+    if (post.imageFileId) {
+      await deleteFileFromDrive(post.imageFileId);
+    }
+
+    await logAction({
+      userId: user.id,
+      userName: user.displayName || user.primaryEmail || "Unknown",
+      action: "DELETE",
+      resourceType: "community_post",
+      resourceId: id,
+      oldValues: {
+        memberId: post.memberId,
+        memberName: post.member.name,
+        content: post.content,
+      },
+      ipAddress: request.headers.get("x-forwarded-for") || undefined,
+      userAgent: request.headers.get("user-agent") || undefined,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof PermissionError) return forbiddenResponse();
+    console.error("Error deleting community post (admin):", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/app/api/admin/community-posts/route.ts
+++ b/apps/sccny/src/app/api/admin/community-posts/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getAdminUser, unauthorizedResponse, forbiddenResponse } from "@/lib/admin-auth";
+import { requirePermission, PermissionError } from "@/lib/permissions";
+import { GetAdminCommunityPostsQuerySchema } from "@/lib/admin-validations";
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getAdminUser();
+    if (!user) return unauthorizedResponse();
+
+    await requirePermission(user.id, "community.manage");
+
+    const { searchParams } = new URL(request.url);
+    const query = GetAdminCommunityPostsQuerySchema.parse(Object.fromEntries(searchParams));
+
+    const where = query.memberId ? { memberId: query.memberId } : {};
+    const skip = (query.page - 1) * query.limit;
+
+    const [posts, total] = await Promise.all([
+      prisma.communityPost.findMany({
+        where,
+        skip,
+        take: query.limit,
+        orderBy: { createdAt: "desc" },
+        include: {
+          member: { select: { id: true, name: true, nameZh: true, email: true } },
+        },
+      }),
+      prisma.communityPost.count({ where }),
+    ]);
+
+    return NextResponse.json({
+      data: posts,
+      pagination: {
+        page: query.page,
+        limit: query.limit,
+        total,
+        totalPages: Math.ceil(total / query.limit),
+      },
+    });
+  } catch (error) {
+    if (error instanceof PermissionError) return forbiddenResponse();
+    console.error("Error fetching community posts (admin):", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/app/api/member/posts/[id]/route.ts
+++ b/apps/sccny/src/app/api/member/posts/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { stackServerApp } from "@/stack/server";
+import { deleteFileFromDrive } from "@/lib/google-drive";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await stackServerApp.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const member = await prisma.member.findUnique({ where: { userId: user.id } });
+    if (!member || member.status !== "ACTIVE") {
+      return NextResponse.json({ error: "Active membership required" }, { status: 403 });
+    }
+
+    const { id } = await params;
+    const post = await prisma.communityPost.findUnique({ where: { id } });
+
+    if (!post) return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    if (post.memberId !== member.id) {
+      return NextResponse.json({ error: "You can only delete your own posts" }, { status: 403 });
+    }
+
+    await prisma.communityPost.delete({ where: { id } });
+
+    if (post.imageFileId) {
+      await deleteFileFromDrive(post.imageFileId);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting community post:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/app/api/member/posts/images/route.ts
+++ b/apps/sccny/src/app/api/member/posts/images/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { stackServerApp } from "@/stack/server";
+import { uploadImageToDrive } from "@/lib/google-drive";
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await stackServerApp.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const member = await prisma.member.findUnique({ where: { userId: user.id } });
+    if (!member || member.status !== "ACTIVE") {
+      return NextResponse.json({ error: "Active membership required" }, { status: 403 });
+    }
+
+    if (!process.env.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS) {
+      return NextResponse.json({ error: "Image upload is not configured" }, { status: 503 });
+    }
+
+    const formData = await request.formData();
+    const file = formData.get("file") as File | null;
+
+    if (!file) return NextResponse.json({ error: "No file provided" }, { status: 400 });
+
+    if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+      return NextResponse.json(
+        { error: "Only JPEG, PNG, GIF, and WebP images are allowed" },
+        { status: 400 }
+      );
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json({ error: "Image must be under 5MB" }, { status: 400 });
+    }
+
+    const bytes = await file.arrayBuffer();
+    const buffer = Buffer.from(bytes);
+    const fileName = `community-${Date.now()}-${file.name}`;
+
+    const { fileId, url } = await uploadImageToDrive(buffer, file.type, fileName);
+
+    return NextResponse.json({ fileId, url }, { status: 201 });
+  } catch (error) {
+    console.error("Error uploading image:", error);
+    return NextResponse.json({ error: "Failed to upload image" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/app/api/member/posts/route.ts
+++ b/apps/sccny/src/app/api/member/posts/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { stackServerApp } from "@/stack/server";
+import { CommunityPostCreateSchema, GetCommunityPostsQuerySchema } from "@/lib/admin-validations";
+async function getActiveMember(userId: string) {
+  const member = await prisma.member.findUnique({ where: { userId } });
+  if (!member || member.status !== "ACTIVE") return null;
+  return member;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await stackServerApp.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const member = await getActiveMember(user.id);
+    if (!member) return NextResponse.json({ error: "Active membership required" }, { status: 403 });
+
+    const { searchParams } = new URL(request.url);
+    const query = GetCommunityPostsQuerySchema.parse(Object.fromEntries(searchParams));
+
+    const skip = (query.page - 1) * query.limit;
+
+    const [posts, total] = await Promise.all([
+      prisma.communityPost.findMany({
+        skip,
+        take: query.limit,
+        orderBy: { createdAt: "desc" },
+        include: {
+          member: { select: { id: true, name: true, nameZh: true, profilePhoto: true } },
+        },
+      }),
+      prisma.communityPost.count(),
+    ]);
+
+    return NextResponse.json({
+      data: posts,
+      pagination: {
+        page: query.page,
+        limit: query.limit,
+        total,
+        totalPages: Math.ceil(total / query.limit),
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching community posts:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await stackServerApp.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const member = await getActiveMember(user.id);
+    if (!member) return NextResponse.json({ error: "Active membership required" }, { status: 403 });
+
+    const body = await request.json();
+    const validated = CommunityPostCreateSchema.parse(body);
+
+    // Read configurable max length from SystemConfig (default 150)
+    const config = await prisma.systemConfig.findUnique({ where: { key: "post_max_length" } });
+    const maxLength = config ? parseInt(config.value) : 150;
+
+    if (validated.content.length > maxLength) {
+      return NextResponse.json(
+        { error: `Post content exceeds the maximum of ${maxLength} characters` },
+        { status: 400 }
+      );
+    }
+
+    const post = await prisma.communityPost.create({
+      data: {
+        memberId: member.id,
+        content: validated.content,
+        imageUrl: validated.imageUrl,
+        imageFileId: validated.imageFileId,
+      },
+      include: {
+        member: { select: { id: true, name: true, nameZh: true, profilePhoto: true } },
+      },
+    });
+
+    return NextResponse.json(post, { status: 201 });
+  } catch (error) {
+    if (error instanceof Error && error.name === "ZodError") {
+      return NextResponse.json(
+        { error: "Validation failed", details: (error as unknown as { errors: unknown }).errors },
+        { status: 400 }
+      );
+    }
+    console.error("Error creating community post:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/components/member-corner/CommunityFeed.tsx
+++ b/apps/sccny/src/components/member-corner/CommunityFeed.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle, Button, Badge } from "dark-blue";
+import { useState, useEffect, useRef, useCallback } from "react";
+import Image from "next/image";
+
+interface PostMember {
+  id: string;
+  name: string;
+  nameZh: string | null;
+  profilePhoto: string | null;
+}
+
+interface Post {
+  id: string;
+  content: string;
+  imageUrl: string | null;
+  imageFileId: string | null;
+  createdAt: string;
+  member: PostMember;
+}
+
+interface Pagination {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+interface CommunityFeedProps {
+  currentMemberId: string;
+  maxLength: number;
+}
+
+export default function CommunityFeed({ currentMemberId, maxLength }: CommunityFeedProps) {
+  const t = useTranslations("Community");
+
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+
+  const [content, setContent] = useState("");
+  const [pendingImage, setPendingImage] = useState<{ fileId: string; url: string } | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [uploadingImage, setUploadingImage] = useState(false);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const fetchPosts = useCallback(async (targetPage: number) => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/member/posts?page=${targetPage}&limit=20`);
+      if (res.ok) {
+        const json = await res.json();
+        if (targetPage === 1) {
+          setPosts(json.data);
+        } else {
+          setPosts((prev) => [...prev, ...json.data]);
+        }
+        setPagination(json.pagination);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPosts(1);
+  }, [fetchPosts]);
+
+  async function handleImageSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (file.size > 5 * 1024 * 1024) {
+      setMessage({ type: "error", text: t("imageTooLarge") });
+      return;
+    }
+
+    setImagePreview(URL.createObjectURL(file));
+    setUploadingImage(true);
+    setMessage(null);
+
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const res = await fetch("/api/member/posts/images", { method: "POST", body: formData });
+      if (res.ok) {
+        const json = await res.json();
+        setPendingImage({ fileId: json.fileId, url: json.url });
+      } else {
+        const err = await res.json();
+        setMessage({ type: "error", text: err.error || t("imageUploadError") });
+        setImagePreview(null);
+      }
+    } catch {
+      setMessage({ type: "error", text: t("imageUploadError") });
+      setImagePreview(null);
+    } finally {
+      setUploadingImage(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  }
+
+  function removeImage() {
+    setImagePreview(null);
+    setPendingImage(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!content.trim() || submitting || uploadingImage) return;
+
+    setSubmitting(true);
+    setMessage(null);
+
+    try {
+      const body: Record<string, string | undefined> = { content: content.trim() };
+      if (pendingImage) {
+        body.imageFileId = pendingImage.fileId;
+        body.imageUrl = pendingImage.url;
+      }
+
+      const res = await fetch("/api/member/posts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (res.ok) {
+        const newPost = await res.json();
+        setPosts((prev) => [newPost, ...prev]);
+        setContent("");
+        setPendingImage(null);
+        setImagePreview(null);
+        setMessage({ type: "success", text: t("postSuccess") });
+      } else {
+        const err = await res.json();
+        setMessage({ type: "error", text: err.error || t("postError") });
+      }
+    } catch {
+      setMessage({ type: "error", text: t("postError") });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDelete(postId: string) {
+    try {
+      const res = await fetch(`/api/member/posts/${postId}`, { method: "DELETE" });
+      if (res.ok) {
+        setPosts((prev) => prev.filter((p) => p.id !== postId));
+        setMessage({ type: "success", text: t("deleteSuccess") });
+      } else {
+        setMessage({ type: "error", text: t("deleteError") });
+      }
+    } catch {
+      setMessage({ type: "error", text: t("deleteError") });
+    }
+  }
+
+  function loadMore() {
+    const nextPage = page + 1;
+    setPage(nextPage);
+    fetchPosts(nextPage);
+  }
+
+  const remaining = maxLength - content.length;
+  const isOverLimit = remaining < 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Composer */}
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("newPost")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {message && (
+            <p className={`text-sm mb-3 ${message.type === "success" ? "text-green-600" : "text-destructive"}`}>
+              {message.text}
+            </p>
+          )}
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div className="relative">
+              <textarea
+                className="w-full rounded-md border border-border bg-background p-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary resize-none"
+                rows={3}
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder={t("postPlaceholder")}
+                maxLength={maxLength + 50}
+              />
+              <span className={`absolute bottom-2 right-3 text-xs ${isOverLimit ? "text-destructive font-semibold" : "text-muted-foreground"}`}>
+                {remaining}
+              </span>
+            </div>
+
+            {imagePreview && (
+              <div className="relative inline-block">
+                <Image
+                  src={imagePreview}
+                  alt="Preview"
+                  width={200}
+                  height={150}
+                  className="rounded-md object-cover max-h-40 w-auto"
+                  unoptimized
+                />
+                <button
+                  type="button"
+                  onClick={removeImage}
+                  className="absolute -top-2 -right-2 bg-destructive text-destructive-foreground rounded-full w-5 h-5 text-xs flex items-center justify-center"
+                  aria-label={t("removeImage")}
+                >
+                  ×
+                </button>
+              </div>
+            )}
+
+            <div className="flex items-center gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/gif,image/webp"
+                onChange={handleImageSelect}
+                className="hidden"
+                id="community-image-upload"
+              />
+              <label
+                htmlFor="community-image-upload"
+                className="cursor-pointer text-sm text-muted-foreground hover:text-foreground border border-border rounded-md px-3 py-1.5 transition-colors"
+              >
+                {uploadingImage ? "..." : t("addImage")}
+              </label>
+
+              <Button
+                type="submit"
+                size="sm"
+                disabled={submitting || !content.trim() || isOverLimit || uploadingImage}
+              >
+                {submitting ? t("posting") : t("post")}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {/* Feed */}
+      <div className="space-y-4">
+        {loading && posts.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-8">{t("loading")}</p>
+        ) : posts.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-8">{t("noPostsYet")}</p>
+        ) : (
+          posts.map((post) => (
+            <Card key={post.id}>
+              <CardContent className="pt-4">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span className="text-sm font-medium text-foreground">
+                        {post.member.name}
+                        {post.member.nameZh && (
+                          <span className="text-muted-foreground font-normal"> ({post.member.nameZh})</span>
+                        )}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {new Date(post.createdAt).toLocaleDateString(undefined, {
+                          month: "short",
+                          day: "numeric",
+                          year: "numeric",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </span>
+                    </div>
+                    <p className="text-sm text-foreground whitespace-pre-wrap break-words">{post.content}</p>
+                    {post.imageUrl && (
+                      <div className="mt-3">
+                        <Image
+                          src={post.imageUrl}
+                          alt="Post image"
+                          width={400}
+                          height={300}
+                          className="rounded-md object-cover max-h-64 w-auto"
+                          unoptimized
+                        />
+                      </div>
+                    )}
+                  </div>
+                  {post.member.id === currentMemberId && (
+                    <button
+                      onClick={() => handleDelete(post.id)}
+                      className="text-xs text-muted-foreground hover:text-destructive transition-colors shrink-0"
+                      title={t("deletePost")}
+                    >
+                      {t("deletePost")}
+                    </button>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))
+        )}
+
+        {pagination && pagination.page < pagination.totalPages && (
+          <div className="text-center">
+            <Button variant="outline" size="sm" onClick={loadMore} disabled={loading}>
+              {loading ? "..." : t("loadMore")}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/sccny/src/components/member-corner/MemberDashboard.tsx
+++ b/apps/sccny/src/components/member-corner/MemberDashboard.tsx
@@ -86,11 +86,16 @@ export default function MemberDashboard({ member }: MemberDashboardProps) {
         )}
       </div>
 
-      {/* Prayer Requests link (ACTIVE only) */}
+      {/* ACTIVE-only actions */}
       {member.status === "ACTIVE" && (
-        <Link href="/my-account/prayer-requests">
-          <Button variant="outline">{t("prayerRequests")}</Button>
-        </Link>
+        <div className="flex gap-3 flex-wrap">
+          <Link href="/my-account/prayer-requests">
+            <Button variant="outline">{t("prayerRequests")}</Button>
+          </Link>
+          <Link href="/my-account/community">
+            <Button variant="outline">{t("community")}</Button>
+          </Link>
+        </div>
       )}
     </div>
   );

--- a/apps/sccny/src/lib/admin-validations.ts
+++ b/apps/sccny/src/lib/admin-validations.ts
@@ -393,6 +393,25 @@ export const TranslationEntryCreateSchema = z.object({
   language: z.string().max(10).optional().default("zh"),
 });
 
+// ── Phase 5: Community Feed ──
+
+export const CommunityPostCreateSchema = z.object({
+  content: z.string().min(1, "Content is required").max(500),
+  imageFileId: z.string().optional(),
+  imageUrl: z.string().url().optional(),
+});
+
+export const GetCommunityPostsQuerySchema = z.object({
+  page: z.string().optional().default("1").transform((val) => parseInt(val)),
+  limit: z.string().optional().default("20").transform((val) => Math.min(parseInt(val), 50)),
+});
+
+export const GetAdminCommunityPostsQuerySchema = z.object({
+  page: z.string().optional().default("1").transform((val) => parseInt(val)),
+  limit: z.string().optional().default("20").transform((val) => Math.min(parseInt(val), 100)),
+  memberId: z.string().optional(),
+});
+
 // Types
 export type GetHymnsQueryType = z.infer<typeof GetHymnsQuerySchema>;
 export type HymnCreateType = z.infer<typeof HymnCreateSchema>;
@@ -426,3 +445,6 @@ export type MemberUpdateType = z.infer<typeof MemberUpdateSchema>;
 export type MemberRejectType = z.infer<typeof MemberRejectSchema>;
 export type MemberProfileUpdateType = z.infer<typeof MemberProfileUpdateSchema>;
 export type PrayerRequestCreateType = z.infer<typeof PrayerRequestCreateSchema>;
+export type CommunityPostCreateType = z.infer<typeof CommunityPostCreateSchema>;
+export type GetCommunityPostsQueryType = z.infer<typeof GetCommunityPostsQuerySchema>;
+export type GetAdminCommunityPostsQueryType = z.infer<typeof GetAdminCommunityPostsQuerySchema>;

--- a/apps/sccny/src/lib/google-drive.ts
+++ b/apps/sccny/src/lib/google-drive.ts
@@ -1,0 +1,67 @@
+import { google } from "googleapis";
+import { Readable } from "stream";
+
+function getDriveClient() {
+  const credentials = process.env.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS;
+  if (!credentials) {
+    throw new Error("GOOGLE_SERVICE_ACCOUNT_CREDENTIALS is not configured");
+  }
+
+  const auth = new google.auth.GoogleAuth({
+    credentials: JSON.parse(credentials),
+    scopes: ["https://www.googleapis.com/auth/drive.file"],
+  });
+
+  return google.drive({ version: "v3", auth });
+}
+
+export async function uploadImageToDrive(
+  fileBuffer: Buffer,
+  mimeType: string,
+  fileName: string
+): Promise<{ fileId: string; url: string }> {
+  const drive = getDriveClient();
+  const folderId = process.env.GOOGLE_DRIVE_FOLDER_ID;
+
+  const fileMetadata: { name: string; parents?: string[] } = { name: fileName };
+  if (folderId) {
+    fileMetadata.parents = [folderId];
+  }
+
+  const media = {
+    mimeType,
+    body: Readable.from(fileBuffer),
+  };
+
+  const response = await drive.files.create({
+    requestBody: fileMetadata,
+    media,
+    fields: "id",
+  });
+
+  const fileId = response.data.id!;
+
+  // Make the file publicly readable
+  await drive.permissions.create({
+    fileId,
+    requestBody: {
+      type: "anyone",
+      role: "reader",
+    },
+  });
+
+  return {
+    fileId,
+    url: `https://drive.google.com/uc?id=${fileId}`,
+  };
+}
+
+export async function deleteFileFromDrive(fileId: string): Promise<void> {
+  try {
+    const drive = getDriveClient();
+    await drive.files.delete({ fileId });
+  } catch (error) {
+    // Log but don't throw — post deletion should proceed even if Drive cleanup fails
+    console.error("Failed to delete Drive file:", fileId, error);
+  }
+}

--- a/apps/sccny/src/messages/en.json
+++ b/apps/sccny/src/messages/en.json
@@ -540,7 +540,27 @@
       "reapplying": "Re-applying...",
       "inactiveTitle": "Account Inactive",
       "inactiveMessage": "Your member account is currently inactive. Please contact the church office."
-    }
+    },
+    "community": "Community"
+  },
+  "Community": {
+    "title": "Community",
+    "newPost": "New Post",
+    "postPlaceholder": "Share something with the community...",
+    "addImage": "Add Image",
+    "removeImage": "Remove",
+    "post": "Post",
+    "posting": "Posting...",
+    "deletePost": "Delete",
+    "noPostsYet": "No posts yet. Be the first to share!",
+    "loading": "Loading...",
+    "loadMore": "Load more",
+    "postSuccess": "Your post was shared.",
+    "postError": "Failed to post. Please try again.",
+    "deleteSuccess": "Post deleted.",
+    "deleteError": "Failed to delete post.",
+    "imageUploadError": "Failed to upload image.",
+    "imageTooLarge": "Image must be under 5MB."
   },
   "SermonManagement": {
     "title": "Sermon Management",

--- a/apps/sccny/src/messages/zh.json
+++ b/apps/sccny/src/messages/zh.json
@@ -540,7 +540,27 @@
       "reapplying": "重新申请中...",
       "inactiveTitle": "账户未激活",
       "inactiveMessage": "您的会友账户目前处于未激活状态，请联系教会办公室。"
-    }
+    },
+    "community": "社区"
+  },
+  "Community": {
+    "title": "社区",
+    "newPost": "发帖",
+    "postPlaceholder": "与大家分享...",
+    "addImage": "添加图片",
+    "removeImage": "删除",
+    "post": "发布",
+    "posting": "发布中...",
+    "deletePost": "删除",
+    "noPostsYet": "还没有帖子，来发第一条吧！",
+    "loading": "加载中...",
+    "loadMore": "加载更多",
+    "postSuccess": "帖子已发布。",
+    "postError": "发布失败，请重试。",
+    "deleteSuccess": "帖子已删除。",
+    "deleteError": "删除失败。",
+    "imageUploadError": "图片上传失败。",
+    "imageTooLarge": "图片不能超过 5MB。"
   },
   "SermonManagement": {
     "title": "讲道管理",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
+      googleapis:
+        specifier: ^171.4.0
+        version: 171.4.0
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -755,6 +758,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -948,6 +955,10 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@prisma/adapter-pg@7.4.0':
     resolution: {integrity: sha512-LWwTHaio0bMxvzahmpwpWqsZM0vTfMqwF8zo06YvILL/o47voaSfKzCVxZw/o9awf4fRgS5Vgthobikj9Dusaw==}
@@ -2361,6 +2372,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -2368,9 +2383,17 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2458,6 +2481,9 @@ packages:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
     engines: {node: '>= 0.6.0'}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.0:
     resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
     engines: {node: '>=6.0.0'}
@@ -2470,6 +2496,9 @@ packages:
   bcryptjs@3.0.3:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   bn.js@4.12.3:
     resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
@@ -2504,6 +2533,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   c12@3.1.0:
     resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
@@ -2660,6 +2692,10 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -2772,6 +2808,12 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   effect@3.18.4:
     resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
@@ -2992,6 +3034,9 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
@@ -3024,6 +3069,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
@@ -3072,6 +3121,10 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3086,6 +3139,14 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gaxios@7.1.3:
+    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
@@ -3136,6 +3197,11 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@13.0.5:
     resolution: {integrity: sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw==}
     engines: {node: 20 || >=22}
@@ -3151,6 +3217,22 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  google-auth-library@10.6.1:
+    resolution: {integrity: sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  googleapis-common@8.0.1:
+    resolution: {integrity: sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==}
+    engines: {node: '>=18.0.0'}
+
+  googleapis@171.4.0:
+    resolution: {integrity: sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==}
+    engines: {node: '>=18'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -3209,6 +3291,10 @@ packages:
 
   http-status-codes@2.3.0:
     resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   https@1.0.0:
     resolution: {integrity: sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==}
@@ -3391,6 +3477,9 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -3413,6 +3502,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -3438,6 +3530,12 @@ packages:
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3547,6 +3645,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
@@ -3684,8 +3785,17 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -3796,6 +3906,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -3945,6 +4059,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -4090,6 +4208,10 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
@@ -4216,6 +4338,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
     engines: {node: '>= 0.4'}
@@ -4245,6 +4371,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -4426,6 +4556,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -4474,6 +4607,10 @@ packages:
       typescript:
         optional: true
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
@@ -4514,6 +4651,14 @@ packages:
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -5367,6 +5512,15 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5522,6 +5676,9 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@prisma/adapter-pg@7.4.0':
     dependencies:
@@ -7093,6 +7250,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -7102,9 +7261,13 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
 
@@ -7215,11 +7378,15 @@ snapshots:
 
   base64-arraybuffer@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.0: {}
 
   baseline-browser-mapping@2.9.19: {}
 
   bcryptjs@3.0.3: {}
+
+  bignumber.js@9.3.1: {}
 
   bn.js@4.12.3: {}
 
@@ -7257,6 +7424,8 @@ snapshots:
       electron-to-chromium: 1.5.286
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   c12@3.1.0:
     dependencies:
@@ -7440,6 +7609,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -7537,6 +7708,12 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.1.2
 
   effect@3.18.4:
     dependencies:
@@ -7718,8 +7895,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 10.0.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.0.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.0.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.0(jiti@2.6.1)))(eslint@10.0.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.0(jiti@2.6.1)))(eslint@10.0.0(jiti@2.6.1)))(eslint@10.0.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.0.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@10.0.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@10.0.0(jiti@2.6.1))
@@ -7741,7 +7918,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.0.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.0(jiti@2.6.1)))(eslint@10.0.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7752,22 +7929,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.0.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.0(jiti@2.6.1)))(eslint@10.0.0(jiti@2.6.1)))(eslint@10.0.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@10.0.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.0(jiti@2.6.1)))(eslint@10.0.0(jiti@2.6.1)))(eslint@10.0.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 10.0.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.0.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.0(jiti@2.6.1)))(eslint@10.0.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.0.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.0(jiti@2.6.1)))(eslint@10.0.0(jiti@2.6.1)))(eslint@10.0.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7778,7 +7955,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.0.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@10.0.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.0(jiti@2.6.1)))(eslint@10.0.0(jiti@2.6.1)))(eslint@10.0.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7926,6 +8103,8 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  extend@3.0.2: {}
+
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
@@ -7955,6 +8134,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   fflate@0.4.8: {}
 
@@ -8002,6 +8186,10 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fsevents@2.3.3:
     optional: true
 
@@ -8017,6 +8205,23 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gaxios@7.1.3:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.3
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generate-function@2.3.1:
     dependencies:
@@ -8077,6 +8282,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@13.0.5:
     dependencies:
       minimatch: 10.2.2
@@ -8091,6 +8305,36 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
+
+  google-auth-library@10.6.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.3
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  googleapis-common@8.0.1:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 7.1.3
+      google-auth-library: 10.6.1
+      qs: 6.15.0
+      url-template: 2.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  googleapis@171.4.0:
+    dependencies:
+      google-auth-library: 10.6.1
+      googleapis-common: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   gopd@1.2.0: {}
 
@@ -8147,6 +8391,13 @@ snapshots:
       entities: 7.0.1
 
   http-status-codes@2.3.0: {}
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https@1.0.0: {}
 
@@ -8332,6 +8583,12 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@2.6.1: {}
 
   jose@6.1.3: {}
@@ -8345,6 +8602,10 @@ snapshots:
       argparse: 2.0.1
 
   jsesc@3.1.0: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
 
   json-buffer@3.0.1: {}
 
@@ -8371,6 +8632,17 @@ snapshots:
       pako: 1.0.11
       readable-stream: 2.3.8
       setimmediate: 1.0.5
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.1.2
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.1.2
 
   keyv@4.5.4:
     dependencies:
@@ -8457,6 +8729,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.2.6: {}
 
@@ -8587,7 +8861,15 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
+  node-domexception@1.0.0: {}
+
   node-fetch-native@1.6.7: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-releases@2.0.27: {}
 
@@ -8708,6 +8990,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -8849,6 +9136,10 @@ snapshots:
       dijkstrajs: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
+
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
 
@@ -8992,6 +9283,10 @@ snapshots:
   retry@0.12.0: {}
 
   reusify@1.1.0: {}
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.5.0
 
   rimraf@6.1.3:
     dependencies:
@@ -9161,6 +9456,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string.prototype.includes@2.0.1:
     dependencies:
       call-bind: 1.0.8
@@ -9218,6 +9519,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -9409,6 +9714,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-template@2.0.8: {}
+
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -9445,6 +9752,8 @@ snapshots:
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
+
+  web-streams-polyfill@3.3.3: {}
 
   whatwg-encoding@3.1.1:
     dependencies:
@@ -9506,6 +9815,18 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   xtend@4.0.2: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,9 @@
         "POSTGRES_URL_NO_SSL",
         "POSTGRES_HOST",
         "NEON_PROJECT_ID",
-        "CRON_SECRET"
+        "CRON_SECRET",
+        "GOOGLE_SERVICE_ACCOUNT_CREDENTIALS",
+        "GOOGLE_DRIVE_FOLDER_ID"
       ]
     },
     "dev": {


### PR DESCRIPTION
## Summary

- Adds a Twitter-like post/image sharing feed at `/my-account/community`, accessible to ACTIVE members only
- Posts are stored in Neon/PostgreSQL; images are uploaded to Google Drive via service account and linked by public URL
- Post character limit (default 150) is stored in a new `SystemConfig` table — configurable without a redeploy
- Admin moderation panel via `GET/DELETE /api/admin/community-posts` guarded by the new `community.manage` permission

## Changes

**Schema**
- `SystemConfig` model (key-value settings table); seeded `post_max_length = 150`
- `CommunityPost` model with optional `imageUrl` / `imageFileId` fields
- `community.manage` permission added and seeded into SUPER_ADMIN / ADMIN roles

**API — Member**
- `GET /api/member/posts` — paginated feed (ACTIVE only)
- `POST /api/member/posts` — create post; enforces `post_max_length` at runtime
- `DELETE /api/member/posts/[id]` — delete own post; removes Drive file if present
- `POST /api/member/posts/images` — upload image to Drive (JPEG/PNG/GIF/WebP, ≤5 MB); returns `503` if Drive credentials not yet configured

**API — Admin**
- `GET /api/admin/community-posts` — all posts with pagination
- `DELETE /api/admin/community-posts/[id]` — delete any post + audit log entry

**UI**
- `CommunityFeed` client component: composer with live char counter, image picker, paginated feed, per-author delete
- `/my-account/community` page — redirects non-ACTIVE members
- Community button added to `MemberDashboard` for ACTIVE members
- Bilingual i18n keys (`Community` namespace in `en.json` / `zh.json`)

**Config**
- `googleapis` package added
- `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS` and `GOOGLE_DRIVE_FOLDER_ID` added to `turbo.json` env allowlist

## Test plan

- [ ] Sign in as a non-ACTIVE member → `/my-account/community` redirects to `/my-account`
- [ ] Sign in as an ACTIVE member → Community button visible on dashboard
- [ ] Create a text-only post → appears in feed with name and timestamp
- [ ] Character counter turns red at limit; submit blocked when over limit
- [ ] Add and remove an image before posting (requires Drive env vars)
- [ ] Image larger than 5 MB is rejected client-side and server-side
- [ ] Delete own post → removed from feed
- [ ] Attempt to delete another member's post → 403
- [ ] Admin with `community.manage` can see all posts and delete any
- [ ] Without Drive credentials, image upload returns 503 (text-only posts still work)

## Environment variables required (for image uploads)

```
GOOGLE_SERVICE_ACCOUNT_CREDENTIALS=<JSON string of service account key>
GOOGLE_DRIVE_FOLDER_ID=<Drive folder ID>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)