### PR TITLE
feat: add Member Corner link to top navigation

### DIFF
--- a/apps/sccny/src/components/Navigation.tsx
+++ b/apps/sccny/src/components/Navigation.tsx
@@ -30,6 +30,7 @@ const navigation = [
   { name: "NEWS", href: "/news" },
   { name: "PASTORAL SEARCH", href: "/pastoral-search" },
   { name: "CONTACT US", href: "/contact" },
+  { name: "MEMBER CORNER", href: "/my-account" },
 ];
 
 const languageOptions = [

--- a/apps/sccny/src/messages/en.json
+++ b/apps/sccny/src/messages/en.json
@@ -15,6 +15,7 @@
     "NEWS": "News",
     "PASTORAL SEARCH": "Pastoral Search",
     "CONTACT US": "Contact Us",
+    "MEMBER CORNER": "Member Corner",
     "LANGUAGE": "Language"
   },
   "Home": {

--- a/apps/sccny/src/messages/zh.json
+++ b/apps/sccny/src/messages/zh.json
@@ -15,6 +15,7 @@
     "NEWS": "新闻",
     "PASTORAL SEARCH": "寻牧启事",
     "CONTACT US": "联系我们",
+    "MEMBER CORNER": "会员专区",
     "LANGUAGE": "语言"
   },
   "Home": {


### PR DESCRIPTION
## Summary

- Add "Member Corner" as the last top nav item linking to `/my-account`
- Add bilingual translation keys: `"Member Corner"` (en) / `"会员专区"` (zh)
- Unauthenticated users are redirected to sign-in automatically via the existing `/my-account` layout guard

## Test plan

- [ ] Visit the site — "Member Corner" appears as the last nav item on desktop and in the mobile hamburger menu
- [ ] Click "Member Corner" while logged out — redirects to the sign-in page
- [ ] Click "Member Corner" while logged in — lands on the member dashboard (`/my-account`)
- [ ] Switch language to Chinese — nav item shows "会员专区"

🤖 Generated with [Claude Code](https://claude.com/claude-code)