### PR TITLE
feat(ppt): insert YouTube video slide for hymns with a YouTube link

### DIFF
--- a/apps/sccny/src/app/api/tools/ppt/generate-slides/route.ts
+++ b/apps/sccny/src/app/api/tools/ppt/generate-slides/route.ts
@@ -168,11 +168,13 @@ export async function POST(request: NextRequest) {
     // 5. Handle communion slides
     await handleCommunionSlides(presentationId, body.hasCommunion);
 
-    // 6. Copy hymn slides from hymn bank into the presentation (preserves editability)
+    // 6. Copy hymn slides from hymn bank into the presentation (preserves editability).
+    //    Hymns with a YouTube URL get a video slide instead of lyrics; those still
+    //    need the bank for title-slide lookup, but we call even when HYMN_BANK_ID is
+    //    absent so YouTube-only hymns are still processed.
     let missingHymns: string[] = [];
-    if (HYMN_BANK_ID && body.hymns.length > 0) {
-      const hymnTitles = body.hymns.map((h) => h.title);
-      missingHymns = await copyHymnSlides(presentationId, HYMN_BANK_ID, hymnTitles);
+    if (body.hymns.length > 0 && (HYMN_BANK_ID || body.hymns.some((h) => h.youtubeUrl))) {
+      missingHymns = await copyHymnSlides(presentationId, HYMN_BANK_ID || "", body.hymns);
     }
 
     const presentationUrl = buildPresentationUrl(presentationId);

--- a/apps/sccny/src/components/tools/ppt/WorshipOrderReviewForm.tsx
+++ b/apps/sccny/src/components/tools/ppt/WorshipOrderReviewForm.tsx
@@ -136,28 +136,36 @@ export default function WorshipOrderReviewForm({
           {data.hymns.length === 0 && (
             <p className="text-sm text-muted-foreground">未检测到诗歌</p>
           )}
-          <div className="space-y-2">
+          <div className="space-y-3">
             {data.hymns.map((hymn, i) => (
-              <div key={i} className="flex items-center gap-2">
+              <div key={i} className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <input
+                    className="w-20 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    value={hymn.number}
+                    onChange={(e) => updateHymn(i, "number", e.target.value)}
+                    placeholder="编号"
+                  />
+                  <input
+                    className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    value={hymn.title}
+                    onChange={(e) => updateHymn(i, "title", e.target.value)}
+                    placeholder="诗歌名称"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeHymn(i)}
+                    className="text-muted-foreground hover:text-destructive text-sm px-2"
+                  >
+                    删除
+                  </button>
+                </div>
                 <input
-                  className="w-20 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  value={hymn.number}
-                  onChange={(e) => updateHymn(i, "number", e.target.value)}
-                  placeholder="编号"
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  value={hymn.youtubeUrl ?? ""}
+                  onChange={(e) => updateHymn(i, "youtubeUrl", e.target.value)}
+                  placeholder="YouTube 链接（选填，填写后以视频幻灯片替代歌词）"
                 />
-                <input
-                  className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  value={hymn.title}
-                  onChange={(e) => updateHymn(i, "title", e.target.value)}
-                  placeholder="诗歌名称"
-                />
-                <button
-                  type="button"
-                  onClick={() => removeHymn(i)}
-                  className="text-muted-foreground hover:text-destructive text-sm px-2"
-                >
-                  删除
-                </button>
               </div>
             ))}
           </div>

--- a/apps/sccny/src/lib/google-slides.ts
+++ b/apps/sccny/src/lib/google-slides.ts
@@ -271,6 +271,16 @@ export async function addScriptureSlides(
   }
 }
 
+// ── YouTube helpers ───────────────────────────────────────────────────────────
+
+/** Extract YouTube video ID from a URL (watch?v=, youtu.be/, or embed/). */
+function extractYouTubeId(url: string): string | null {
+  const match = url.match(
+    /(?:youtube\.com\/(?:watch\?(?:.*&)?v=|embed\/)|youtu\.be\/)([A-Za-z0-9_-]{11})/
+  );
+  return match ? match[1] : null;
+}
+
 // ── Hymn slide copy ───────────────────────────────────────────────────────────
 
 /** Extract slide text for hymn-title matching. */
@@ -314,14 +324,18 @@ function findHymnPageIds(
  * inserting them immediately after the corresponding hymn title slide
  * (identified by containing both the hymn title and "颂诗 HYMN").
  * The first slide in the bank for each hymn (the title slide) is skipped.
+ *
+ * If a hymn has a youtubeUrl, a YouTube video slide is inserted instead of
+ * lyrics slides and no bank lookup is performed for that hymn.
  */
 export async function copyHymnSlides(
   targetPresentationId: string,
   hymnBankId: string,
-  hymnTitles: string[],
+  hymns: Array<{ title: string; youtubeUrl?: string }>,
 ): Promise<string[]> {
   const missingHymns: string[] = [];
-  if (hymnTitles.length === 0) return missingHymns;
+  if (hymns.length === 0) return missingHymns;
+  const hymnTitles = hymns.map((h) => h.title);
 
   const slides = getSlidesClient();
 
@@ -335,21 +349,8 @@ export async function copyHymnSlides(
 
   let insertionOffset = 0; // tracks extra slides inserted so far
 
-  for (const title of hymnTitles) {
-    const allPageIds = findHymnPageIds(bankSlides, title);
-    if (allPageIds.length === 0) {
-      console.warn(`copyHymnSlides: no slides found for hymn "${title}"`);
-      missingHymns.push(title);
-      continue;
-    }
-
-    // Skip the first slide (title slide in the bank); only copy lyrics
-    const pageIds = allPageIds.slice(1);
-    if (pageIds.length === 0) {
-      console.warn(`copyHymnSlides: only a title slide found for hymn "${title}", no lyrics`);
-      missingHymns.push(title);
-      continue;
-    }
+  for (const hymn of hymns) {
+    const title = hymn.title;
 
     // Find the hymn title slide in the target presentation:
     // must contain both the hymn title AND "颂诗 HYMN"
@@ -367,8 +368,75 @@ export async function copyHymnSlides(
       continue;
     }
 
+    // Insert right after the title slide
+    const insertIndex = titleSlideIndex + 1 + insertionOffset;
+
+    // ── YouTube path: insert a video slide, skip lyrics ──────────────────────
+    if (hymn.youtubeUrl) {
+      const videoId = extractYouTubeId(hymn.youtubeUrl);
+      if (!videoId) {
+        console.warn(`copyHymnSlides: could not extract YouTube ID from "${hymn.youtubeUrl}"`);
+      } else {
+        const videoSlideId = `hymn_yt_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+        const videoElemId = `${videoSlideId}_vid`;
+        await slides.presentations.batchUpdate({
+          presentationId: targetPresentationId,
+          requestBody: {
+            requests: [
+              {
+                createSlide: {
+                  objectId: videoSlideId,
+                  insertionIndex: insertIndex,
+                  slideLayoutReference: { predefinedLayout: "BLANK" },
+                },
+              },
+              {
+                createVideo: {
+                  objectId: videoElemId,
+                  source: "YOUTUBE",
+                  id: videoId,
+                  elementProperties: {
+                    pageObjectId: videoSlideId,
+                    size: {
+                      width: { magnitude: 9144000, unit: "EMU" },
+                      height: { magnitude: 5143500, unit: "EMU" },
+                    },
+                    transform: {
+                      scaleX: 1,
+                      scaleY: 1,
+                      translateX: 0,
+                      translateY: 0,
+                      unit: "EMU",
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        });
+        insertionOffset++;
+      }
+      continue;
+    }
+
+    // ── Standard path: copy lyrics slides from hymn bank ────────────────────
+    const allPageIds = findHymnPageIds(bankSlides, title);
+    if (allPageIds.length === 0) {
+      console.warn(`copyHymnSlides: no slides found for hymn "${title}"`);
+      missingHymns.push(title);
+      continue;
+    }
+
+    // Skip the first slide (title slide in the bank); only copy lyrics
+    const pageIds = allPageIds.slice(1);
+    if (pageIds.length === 0) {
+      console.warn(`copyHymnSlides: only a title slide found for hymn "${title}", no lyrics`);
+      missingHymns.push(title);
+      continue;
+    }
+
     // Insert lyrics slides right after the title slide
-    let currentIndex = titleSlideIndex + 1 + insertionOffset;
+    let currentIndex = insertIndex;
 
     for (const pageId of pageIds) {
       const src = bankSlides.find((s) => s.objectId === pageId);

--- a/apps/sccny/src/lib/parse-worship-order.ts
+++ b/apps/sccny/src/lib/parse-worship-order.ts
@@ -4,6 +4,8 @@ export interface HymnEntry {
   raw: string;
   /** True for 回应诗歌 (response hymn); false/absent for all other hymns */
   isResponse?: boolean;
+  /** YouTube URL if provided on the hymn line — video slide replaces lyrics slides */
+  youtubeUrl?: string;
 }
 
 export interface WorshipOrderData {
@@ -35,14 +37,27 @@ export interface WorshipOrderData {
  * Parse a hymn line like "诗歌：12 你真伟大" or "回应诗歌：441 洁净我"
  * Returns { number, title, raw } or null if not parseable.
  */
+function extractYouTubeUrl(text: string): { youtubeUrl: string; textWithoutUrl: string } | null {
+  const match = text.match(/\s+(https?:\/\/(?:www\.)?(?:youtube\.com\/watch\?[^\s]*v=|youtu\.be\/)[^\s]+)/);
+  if (!match) return null;
+  return {
+    youtubeUrl: match[1],
+    textWithoutUrl: text.slice(0, match.index!).trim(),
+  };
+}
+
 function parseHymnLine(text: string): HymnEntry | null {
   // text is already stripped of the prefix (e.g. "12 你真伟大")
-  const match = text.trim().match(/^(\d+)\s+(.+)$/);
+  const trimmed = text.trim();
+  const extracted = extractYouTubeUrl(trimmed);
+  const cleanText = extracted ? extracted.textWithoutUrl : trimmed;
+  const match = cleanText.match(/^(\d+)\s+(.+)$/);
   if (!match) return null;
   return {
     number: match[1],
     title: match[2].trim(),
-    raw: text.trim(),
+    raw: trimmed,
+    ...(extracted ? { youtubeUrl: extracted.youtubeUrl } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

- When a hymn line includes a YouTube URL (`youtu.be/…` or `youtube.com/watch?v=…`), the parser extracts it into a new `youtubeUrl` field on `HymnEntry`
- During slide generation, hymns with a YouTube URL get a **full-screen YouTube video slide** inserted immediately after the hymn title slide — no lyrics slides are added
- Hymns without a YouTube URL continue to use the existing hymn bank lyrics copy behavior
- A YouTube URL input field is shown per hymn in the review form (step 2), pre-filled if parsed from the worship order text

## Test plan

- [ ] Enter a hymn line with a YouTube URL (e.g. `诗歌：12 你真伟大 https://youtu.be/abc123`) in the worship order input
- [ ] Confirm the YouTube URL is pre-filled in the review form for that hymn
- [ ] Generate slides and verify a YouTube video slide appears after the hymn title slide (no lyrics slides)
- [ ] Confirm hymns without a URL still get lyrics slides copied from the hymn bank
- [ ] Verify manually entering a YouTube URL in the review form also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)