### PR TITLE
feat(ppt): allow custom text for 宣召 slide

### DIFF
--- a/apps/sccny/src/app/api/tools/ppt/generate-slides/route.ts
+++ b/apps/sccny/src/app/api/tools/ppt/generate-slides/route.ts
@@ -155,7 +155,9 @@ export async function POST(request: NextRequest) {
     await replaceVerseContent(
       presentationId,
       [
-        { keyword: "宣召", vetitle: body.callToWorship, verse: body.callToWorship },
+        body.callToWorshipCustomText
+          ? { keyword: "宣召", vetitle: "", verse: body.callToWorshipCustomText }
+          : { keyword: "宣召", vetitle: body.callToWorship, verse: body.callToWorship },
         { keyword: "读经", vetitle: body.scriptureReading, verse: body.scriptureReading },
         { keyword: "金句", vetitle: body.memoryVerse, verse: body.memoryVerse, noSplit: true },
         { keyword: "认罪", vetitle: body.confessionPrayer, verse: body.confessionPrayer },

--- a/apps/sccny/src/components/tools/ppt/WorshipOrderReviewForm.tsx
+++ b/apps/sccny/src/components/tools/ppt/WorshipOrderReviewForm.tsx
@@ -110,12 +110,25 @@ export default function WorshipOrderReviewForm({
               />
             </div>
             <div className="space-y-1">
-              <label className="text-sm font-medium text-muted-foreground">宣召</label>
+              <label className="text-sm font-medium text-muted-foreground">宣召经文引用</label>
               <input
                 className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 value={data.callToWorship}
                 onChange={(e) => update("callToWorship", e.target.value)}
                 placeholder="如：诗篇51"
+              />
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label className="text-sm font-medium text-muted-foreground">
+                宣召自定义文字
+                <span className="ml-1 text-xs font-normal text-muted-foreground/70">（选填；填写后将直接显示此文字，不查找经文）</span>
+              </label>
+              <textarea
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring resize-none"
+                rows={3}
+                value={data.callToWorshipCustomText ?? ""}
+                onChange={(e) => update("callToWorshipCustomText", e.target.value)}
+                placeholder="如：你们要赞美耶和华！因歌颂我们的神为善为美，颂赞的话是合宜的。"
               />
             </div>
             <div className="space-y-1">

--- a/apps/sccny/src/lib/parse-worship-order.ts
+++ b/apps/sccny/src/lib/parse-worship-order.ts
@@ -21,8 +21,10 @@ export interface WorshipOrderData {
   sermonSubtitle: string;
   /** Speaker / preacher name → summary!B3 */
   speaker: string;
-  /** Call to worship scripture ref */
+  /** Call to worship scripture ref (used for Bible lookup) */
   callToWorship: string;
+  /** Optional custom call-to-worship text; if set, overrides Bible lookup and is shown verbatim */
+  callToWorshipCustomText?: string;
   /** Confession prayer scripture ref */
   confessionPrayer: string;
   /** Assurance scripture ref */


### PR DESCRIPTION
## Summary

- Add optional `callToWorshipCustomText` field to `WorshipOrderData` interface
- Add a textarea in the PPT review form (step 2) where users can enter any free-form text for the 宣召 slide
- When custom text is provided, it is shown verbatim on the slide and Bible lookup is skipped; when empty, existing scripture-reference lookup behavior is unchanged

## Test plan
- [ ] Enter a scripture reference only (e.g. `诗篇51`) — slide should show Bible verse text as before
- [ ] Enter a custom text in the new textarea (e.g. `你们要赞美耶和华！`) — slide should show that text verbatim, no lookup error
- [ ] Leave custom text empty — behavior identical to before this change
- [ ] TypeScript build passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)