### PR TITLE
feat(bible): Google Sheets Bible lookup (same data source as PPT tool)

### DIFF
--- a/apps/sccny/src/app/[locale]/tools/bible/page.tsx
+++ b/apps/sccny/src/app/[locale]/tools/bible/page.tsx
@@ -15,7 +15,6 @@ import {
   CardContent,
   Input,
   Button,
-  Select,
   Skeleton,
   Alert,
   AlertTitle,
@@ -24,6 +23,22 @@ import {
 } from "dark-blue";
 import axios from "axios";
 
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface VerseSegment {
+  zhTitle: string;
+  enTitle: string;
+  zhVerses: string[];
+  enVerses: string[];
+}
+
+interface SheetsApiResponse {
+  status: string;
+  results: VerseSegment[];
+  error?: string;
+}
+
+// Legacy external-API types (fallback)
 interface BibleVerse {
   chineses: string;
   engs: string;
@@ -32,48 +47,68 @@ interface BibleVerse {
   bible_text: string;
 }
 
-interface BibleApiResponse {
+interface ExternalApiResponse {
   status: string;
   record_count: number;
-  proc: number;
   record: BibleVerse[];
 }
 
-type BibleVersion = "unv" | "esv";
+// ── Component ────────────────────────────────────────────────────────────────
 
 export default function BiblePage() {
   const t = useTranslations("Tools.bible");
+
   const [query, setQuery] = useState("");
-  const [version, setVersion] = useState<BibleVersion>("unv");
-  const [results, setResults] = useState<BibleVerse[]>([]);
+  const [segments, setSegments] = useState<VerseSegment[]>([]);
+  const [legacyVerses, setLegacyVerses] = useState<BibleVerse[]>([]);
+  const [usingSheetsSource, setUsingSheetsSource] = useState(true);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [searched, setSearched] = useState(false);
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
 
   const fetchBibleVerse = useCallback(
-    async (searchQuery: string, selectedVersion: BibleVersion) => {
+    async (searchQuery: string) => {
       setLoading(true);
       setError("");
       setSearched(true);
+      setSegments([]);
+      setLegacyVerses([]);
+
       try {
-        const response = await axios.get<BibleApiResponse>(
-          `/api/tools/bible/search?q=${encodeURIComponent(searchQuery)}&version=${selectedVersion}`
+        // Try Google Sheets source first (same data as PPT generation tool)
+        const sheetsRes = await axios.get<SheetsApiResponse>(
+          `/api/tools/bible/sheets-search?q=${encodeURIComponent(searchQuery)}`
         );
 
-        if (
-          response.data.status === "success" &&
-          response.data.record?.length > 0
-        ) {
-          setResults(response.data.record);
+        if (sheetsRes.data.status === "success" && sheetsRes.data.results?.length > 0) {
+          setSegments(sheetsRes.data.results);
+          setUsingSheetsSource(true);
+          return;
+        }
+
+        if (sheetsRes.data.status === "not_found") {
+          setError(t("noResults"));
+          return;
+        }
+      } catch {
+        // Google Sheets unavailable — fall through to external API
+      }
+
+      // Fallback: external bible.fhl.net API
+      try {
+        const externalRes = await axios.get<ExternalApiResponse>(
+          `/api/tools/bible/search?q=${encodeURIComponent(searchQuery)}&version=unv`
+        );
+
+        if (externalRes.data.status === "success" && externalRes.data.record?.length > 0) {
+          setLegacyVerses(externalRes.data.record);
+          setUsingSheetsSource(false);
         } else {
-          setResults([]);
           setError(t("noResults"));
         }
-      } catch (err) {
-        console.error("Bible API Error:", err);
+      } catch {
         setError(t("fetchError"));
-        setResults([]);
       } finally {
         setLoading(false);
       }
@@ -81,13 +116,33 @@ export default function BiblePage() {
     [t]
   );
 
+  // fetchBibleVerse manages its own loading state via the try/finally in the
+  // fallback branch; make sure loading is cleared even when sheets succeeds.
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     if (!query.trim()) return;
-    fetchBibleVerse(query.trim(), version);
+    setLoading(true);
+    fetchBibleVerse(query.trim()).finally(() => setLoading(false));
   };
 
-  const handleCopyVerse = async (verse: BibleVerse, index: number) => {
+  const handleCopySegment = async (seg: VerseSegment, index: number) => {
+    const text = [
+      `${seg.zhTitle}`,
+      seg.zhVerses.join(" "),
+      "",
+      `${seg.enTitle}`,
+      seg.enVerses.join(" "),
+    ].join("\n");
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedIndex(index);
+      setTimeout(() => setCopiedIndex(null), 2000);
+    } catch {
+      // ignore clipboard errors
+    }
+  };
+
+  const handleCopyLegacyVerse = async (verse: BibleVerse, index: number) => {
     const reference = `${verse.chineses || verse.engs} ${verse.chap}:${verse.sec}`;
     const text = `${verse.bible_text}\n-- ${reference}`;
     try {
@@ -95,9 +150,11 @@ export default function BiblePage() {
       setCopiedIndex(index);
       setTimeout(() => setCopiedIndex(null), 2000);
     } catch {
-      // Fallback: ignore clipboard errors
+      // ignore clipboard errors
     }
   };
+
+  const hasResults = segments.length > 0 || legacyVerses.length > 0;
 
   return (
     <>
@@ -116,28 +173,6 @@ export default function BiblePage() {
               <p className="text-muted-foreground mb-8">{t("description")}</p>
 
               <form onSubmit={handleSearch} className="w-full max-w-lg mx-auto">
-                {/* Version Selector */}
-                <div className="flex items-center justify-center gap-2 mb-4">
-                  <label
-                    htmlFor="bible-version"
-                    className="text-sm font-medium text-muted-foreground"
-                  >
-                    {t("version")}:
-                  </label>
-                  <Select
-                    id="bible-version"
-                    value={version}
-                    onChange={(e) =>
-                      setVersion(e.target.value as BibleVersion)
-                    }
-                    className="w-[200px]"
-                  >
-                    <option value="unv">{t("versionCUV")}</option>
-                    <option value="esv">{t("versionESV")}</option>
-                  </Select>
-                </div>
-
-                {/* Search Input */}
                 <div className="relative flex items-center">
                   <Input
                     type="text"
@@ -156,7 +191,6 @@ export default function BiblePage() {
                     <MagnifyingGlassIcon className="h-6 w-6" />
                   </Button>
                 </div>
-
                 <p className="text-xs text-muted-foreground mt-3">
                   {t("searchHint")}
                 </p>
@@ -168,14 +202,22 @@ export default function BiblePage() {
           {(loading || searched) && (
             <div className="mt-6">
               {/* Results Header */}
-              {!loading && results.length > 0 && (
+              {!loading && hasResults && (
                 <div className="flex items-center justify-between mb-4">
                   <h2 className="text-xl font-semibold text-foreground">
                     {t("resultTitle")}
                   </h2>
-                  <Badge variant="outline">
-                    {results.length} {t("versesFound")}
-                  </Badge>
+                  {usingSheetsSource && segments.length > 0 && (
+                    <Badge variant="outline">
+                      {segments.length}{" "}
+                      {segments.length === 1 ? "passage" : "passages"}
+                    </Badge>
+                  )}
+                  {!usingSheetsSource && legacyVerses.length > 0 && (
+                    <Badge variant="outline">
+                      {legacyVerses.length} {t("versesFound")}
+                    </Badge>
+                  )}
                 </div>
               )}
 
@@ -203,10 +245,71 @@ export default function BiblePage() {
                 </Alert>
               )}
 
-              {/* Verse Results */}
-              {!loading && !error && results.length > 0 && (
+              {/* Google Sheets Results (parallel zh/en view) */}
+              {!loading && !error && usingSheetsSource && segments.length > 0 && (
+                <div className="space-y-4">
+                  {segments.map((seg, index) => (
+                    <Card
+                      key={`${seg.zhTitle}-${index}`}
+                      className="transition-all hover:shadow-md"
+                    >
+                      <CardContent className="py-5">
+                        <div className="flex items-start justify-between gap-3 mb-4">
+                          <div className="flex flex-wrap gap-2">
+                            <Badge variant="outline" className="font-semibold">
+                              {seg.zhTitle}
+                            </Badge>
+                            <Badge variant="subtle" className="text-muted-foreground font-normal">
+                              {seg.enTitle}
+                            </Badge>
+                          </div>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="shrink-0 text-muted-foreground hover:text-foreground"
+                            onClick={() => handleCopySegment(seg, index)}
+                            aria-label={t("copyVerse")}
+                          >
+                            <DocumentDuplicateIcon className="h-4 w-4" />
+                            {copiedIndex === index && (
+                              <span className="text-xs ml-1 text-green-600">
+                                {t("copied")}
+                              </span>
+                            )}
+                          </Button>
+                        </div>
+
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                          {/* Chinese text */}
+                          <div>
+                            <p className="text-xs font-medium text-muted-foreground mb-2 uppercase tracking-wide">
+                              {t("chineseLabel")}
+                            </p>
+                            <p className="text-foreground leading-relaxed text-sm">
+                              {seg.zhVerses.join(" ")}
+                            </p>
+                          </div>
+
+                          {/* English text */}
+                          <div>
+                            <p className="text-xs font-medium text-muted-foreground mb-2 uppercase tracking-wide">
+                              {t("englishLabel")}
+                            </p>
+                            <p className="text-foreground leading-relaxed text-sm">
+                              {seg.enVerses.join(" ")}
+                            </p>
+                          </div>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              )}
+
+              {/* Legacy External API Results */}
+              {!loading && !error && !usingSheetsSource && legacyVerses.length > 0 && (
                 <div className="space-y-3">
-                  {results.map((verse, index) => (
+                  {legacyVerses.map((verse, index) => (
                     <Card
                       key={`${verse.chap}-${verse.sec}-${index}`}
                       className="transition-all hover:shadow-md"
@@ -214,11 +317,9 @@ export default function BiblePage() {
                       <CardContent className="py-4">
                         <div className="flex items-start justify-between gap-3">
                           <div className="flex-1 min-w-0">
-                            {/* Verse Reference */}
                             <div className="flex items-center gap-2 mb-2">
                               <Badge variant="outline" className="font-mono text-xs shrink-0">
-                                {verse.chineses || verse.engs} {verse.chap}:
-                                {verse.sec}
+                                {verse.chineses || verse.engs} {verse.chap}:{verse.sec}
                               </Badge>
                               {verse.engs && verse.chineses && (
                                 <span className="text-xs text-muted-foreground truncate">
@@ -226,8 +327,6 @@ export default function BiblePage() {
                                 </span>
                               )}
                             </div>
-
-                            {/* Verse Text */}
                             <p className="text-foreground text-base leading-relaxed">
                               <span className="text-primary font-semibold mr-1">
                                 {verse.sec}
@@ -235,13 +334,11 @@ export default function BiblePage() {
                               {verse.bible_text}
                             </p>
                           </div>
-
-                          {/* Copy Button */}
                           <Button
                             variant="ghost"
                             size="sm"
                             className="shrink-0 text-muted-foreground hover:text-foreground"
-                            onClick={() => handleCopyVerse(verse, index)}
+                            onClick={() => handleCopyLegacyVerse(verse, index)}
                             aria-label={t("copyVerse")}
                           >
                             <DocumentDuplicateIcon className="h-4 w-4" />
@@ -258,8 +355,8 @@ export default function BiblePage() {
                 </div>
               )}
 
-              {/* Empty State (searched but no results and no error) */}
-              {!loading && !error && results.length === 0 && searched && (
+              {/* Empty State */}
+              {!loading && !error && !hasResults && searched && (
                 <Card>
                   <CardContent className="py-12 text-center">
                     <BookOpenIcon className="h-12 w-12 text-muted-foreground mx-auto mb-4" />

--- a/apps/sccny/src/app/api/tools/bible/sheets-search/route.ts
+++ b/apps/sccny/src/app/api/tools/bible/sheets-search/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { lookupBibleVerses } from "@/lib/bible-lookup";
+
+export async function GET(request: NextRequest) {
+  const q = request.nextUrl.searchParams.get("q");
+  if (!q) {
+    return NextResponse.json({ error: "Query is required" }, { status: 400 });
+  }
+
+  try {
+    const results = await lookupBibleVerses(q);
+    return NextResponse.json({ status: results.length > 0 ? "success" : "not_found", results });
+  } catch (error) {
+    console.error("Bible Sheets lookup error:", error);
+    return NextResponse.json({ error: "Failed to fetch Bible data" }, { status: 500 });
+  }
+}

--- a/apps/sccny/src/lib/bible-lookup.ts
+++ b/apps/sccny/src/lib/bible-lookup.ts
@@ -1,0 +1,216 @@
+import "server-only";
+import { google } from "googleapis";
+import fs from "fs";
+
+function getSheetsClient() {
+  const credentialsJson = process.env.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS;
+  const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+  if (!credentialsJson && !credentialsPath) {
+    throw new Error("GOOGLE_SERVICE_ACCOUNT_CREDENTIALS is not configured");
+  }
+
+  const credentials = credentialsJson
+    ? JSON.parse(credentialsJson)
+    : JSON.parse(fs.readFileSync(credentialsPath!, "utf-8"));
+
+  return google.sheets({
+    version: "v4",
+    auth: new google.auth.GoogleAuth({
+      credentials,
+      scopes: ["https://www.googleapis.com/auth/spreadsheets.readonly"],
+    }),
+  });
+}
+
+// ── Book abbreviation map ────────────────────────────────────────────────────
+
+const BOOK_ABBREV_MAP: Record<string, string> = {
+  "林前": "哥林多前书", "林后": "哥林多后书", "林後": "哥林多后书",
+  "帖前": "帖撒罗尼迦前书", "帖后": "帖撒罗尼迦后书", "帖後": "帖撒罗尼迦后书",
+  "提前": "提摩太前书",    "提后": "提摩太后书",    "提後": "提摩太后书",
+  "彼前": "彼得前书",      "彼后": "彼得后书",      "彼後": "彼得后书",
+  "撒上": "撒母耳记上",    "撒下": "撒母耳记下",
+  "王上": "列王纪上",      "王下": "列王纪下",
+  "代上": "历代志上",      "代下": "历代志下",
+  "约一": "约翰一书",      "约二": "约翰二书",   "约三": "约翰三书",
+  "弗":   "以弗所书",      "腓": "腓立比书",     "西": "歌罗西书",
+  "多":   "提多书",        "门": "腓利门书",     "来": "希伯来书",
+  "雅":   "雅各书",        "犹": "犹大书",       "启": "启示录",   "啟": "启示录",
+  "罗":   "罗马书",        "加": "加拉太书",
+  "太":   "马太福音",      "可": "马可福音",     "路": "路加福音",
+  "约":   "约翰福音",      "徒": "使徒行传",
+  "创":   "创世记",        "出": "出埃及记",     "利": "利未记",
+  "民":   "民数记",        "申": "申命记",       "书": "约书亚记",
+  "士":   "士师记",        "得": "路得记",       "拉": "以斯拉记",
+  "尼":   "尼希米记",      "斯": "以斯帖记",     "伯": "约伯记",
+  "诗":   "诗篇",          "詩": "诗篇",         "传": "传道书",   "傳": "传道书",   "歌": "雅歌",
+  "赛":   "以赛亚书",      "耶": "耶利米书",     "哀": "耶利米哀歌",
+  "结":   "以西结书",      "但": "但以理书",     "何": "何西阿书",
+  "珥":   "约珥书",        "摩": "阿摩司书",     "俄": "俄巴底亚书",
+  "拿":   "约拿书",        "弥": "弥迦书",       "鸿": "那鸿书",   "鴻": "那鸿书",
+  "哈":   "哈巴谷书",      "番": "西番雅书",     "该": "哈该书",
+  "亚":   "撒迦利亚书",    "玛": "玛拉基书",
+};
+
+// Pre-sort longest-first so short prefixes don't shadow longer ones.
+const ABBREV_ENTRIES = Object.entries(BOOK_ABBREV_MAP).sort((a, b) => b[0].length - a[0].length);
+
+// ── Pure helpers ─────────────────────────────────────────────────────────────
+
+function expandBookAbbreviation(ref: string): string {
+  for (const [abbrev, full] of ABBREV_ENTRIES) {
+    if (!ref.startsWith(abbrev)) continue;
+    const after = ref.slice(abbrev.length);
+    if (after === "" || /^[\d第\s：:]/.test(after)) return full + after;
+  }
+  return ref;
+}
+
+function normalizeChapterRef(ref: string): string {
+  const cn: Record<string, number> = {
+    "一": 1, "二": 2, "三": 3, "四": 4, "五": 5,
+    "六": 6, "七": 7, "八": 8, "九": 9,
+    "十": 10, "十一": 11, "十二": 12, "十三": 13, "十四": 14, "十五": 15,
+    "十六": 16, "十七": 17, "十八": 18, "十九": 19, "二十": 20,
+    "二十一": 21, "二十二": 22, "二十三": 23, "二十四": 24, "二十五": 25,
+    "二十六": 26, "二十七": 27, "二十八": 28, "二十九": 29, "三十": 30,
+  };
+  return ref.replace(/第([二三四五六七八九十一]+)章/, (_, ch: string) =>
+    cn[ch] !== undefined ? String(cn[ch]) : ch
+  );
+}
+
+function binarySearchLE(arr: number[], target: number): number {
+  let lo = 0, hi = arr.length - 1, result = -1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (arr[mid] <= target) { result = mid; lo = mid + 1; }
+    else hi = mid - 1;
+  }
+  return result;
+}
+
+function parseVerseRef(
+  ref: string,
+  bookNamesList: Array<{ zhName: string; enName: string; bookNum: number }>
+): { bookNum: number; bookZh: string; bookEn: string; chapter: number; startVerse: number; endVerse: number; verseSpecified: boolean } | null {
+  const normalized = normalizeChapterRef(expandBookAbbreviation(ref.trim()));
+  for (const { zhName, enName, bookNum } of bookNamesList) {
+    if (!normalized.startsWith(zhName)) continue;
+    const rest = normalized.slice(zhName.length).trimStart();
+    const m = rest.match(/^(\d+)章?(?:[：:](\d+)(?:[-~](\d+))?)?/);
+    if (!m) continue;
+    const chapter    = parseInt(m[1], 10);
+    const startVerse = m[2] ? parseInt(m[2], 10) : 1;
+    const endVerse   = m[3] ? parseInt(m[3], 10) : startVerse;
+    return { bookNum, bookZh: zhName, bookEn: enName, chapter, startVerse, endVerse, verseSpecified: !!m[2] };
+  }
+  return null;
+}
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface VerseSegment {
+  zhTitle: string;
+  enTitle: string;
+  zhVerses: string[];
+  enVerses: string[];
+}
+
+// ── Fetch ────────────────────────────────────────────────────────────────────
+
+async function fetchSingleRef(
+  bibleSheetId: string,
+  ref: string,
+  bookNamesList: Array<{ zhName: string; enName: string; bookNum: number }>,
+  bibleDataKeys: number[]
+): Promise<VerseSegment | null> {
+  const parsed = parseVerseRef(ref, bookNamesList);
+  if (!parsed) return null;
+
+  const { bookNum, bookZh, bookEn, chapter, startVerse, endVerse, verseSpecified } = parsed;
+  const startKey = bookNum * 1000000 + chapter * 1000 + startVerse;
+  const startIdx = binarySearchLE(bibleDataKeys, startKey);
+
+  if (startIdx < 0 || bibleDataKeys[startIdx] !== startKey) return null;
+
+  const endKey = verseSpecified
+    ? bookNum * 1000000 + chapter * 1000 + endVerse
+    : bookNum * 1000000 + chapter * 1000 + 999;
+  const endIdx = Math.min(binarySearchLE(bibleDataKeys, endKey), bibleDataKeys.length - 1);
+
+  const actualEndVerse = bibleDataKeys[endIdx] % 1000;
+  const verseRange = actualEndVerse === startVerse ? `${startVerse}` : `${startVerse}-${actualEndVerse}`;
+
+  const sheets = getSheetsClient();
+  const res = await sheets.spreadsheets.values.get({
+    spreadsheetId: bibleSheetId,
+    range: `bibleData!B${startIdx + 1}:C${endIdx + 1}`,
+    valueRenderOption: "FORMATTED_VALUE",
+  });
+  const verseRows = (res.data.values || []) as string[][];
+
+  return {
+    zhTitle: `${bookZh} ${chapter}:${verseRange}`,
+    enTitle: `${bookEn || bookZh} ${chapter}:${verseRange}`,
+    zhVerses: verseRows.map((r, i) => `${startVerse + i} ${(r[0] || "").trim()}`),
+    enVerses: verseRows.map((r, i) => `${startVerse + i} ${(r[1] || "").trim()}`),
+  };
+}
+
+/**
+ * Look up Bible verses from the Google Sheets Bible data source.
+ *
+ * Accepts single or multi-range refs (e.g. "约 3:16", "林前1:18-25, 2:1-8").
+ * Returns one VerseSegment per comma-separated range.
+ * Throws if GOOGLE_BIBLE_SHEET_ID or credentials are not configured.
+ */
+export async function lookupBibleVerses(ref: string): Promise<VerseSegment[]> {
+  const bibleSheetId = process.env.GOOGLE_BIBLE_SHEET_ID;
+  if (!bibleSheetId) throw new Error("GOOGLE_BIBLE_SHEET_ID is not configured");
+
+  const sheets = getSheetsClient();
+  const [bnRes, bdRes] = await Promise.all([
+    sheets.spreadsheets.values.get({
+      spreadsheetId: bibleSheetId,
+      range: "bookNames!A:C",
+      valueRenderOption: "FORMATTED_VALUE",
+    }),
+    sheets.spreadsheets.values.get({
+      spreadsheetId: bibleSheetId,
+      range: "bibleData!A:A",
+      valueRenderOption: "FORMATTED_VALUE",
+    }),
+  ]);
+
+  const bookNamesList = ((bnRes.data.values || []) as string[][])
+    .filter((r) => r[0] && r[2] && r[0] !== "----" && !isNaN(parseInt(r[2], 10)))
+    .map((r) => ({ zhName: r[0], enName: r[1] ?? "", bookNum: parseInt(r[2], 10) }))
+    .sort((a, b) => b.zhName.length - a.zhName.length);
+
+  const bibleDataKeys = ((bdRes.data.values || []) as string[][])
+    .map((r) => parseInt(r[0] || "0", 10))
+    .filter((n) => n > 0);
+
+  // Split multi-range refs; segments starting with a digit re-use the previous book prefix.
+  const rawParts = ref.split(/[,;，；]\s*/);
+  const segments: string[] = [];
+  let bookPrefix = "";
+  for (const part of rawParts) {
+    const t = part.trim();
+    if (!t) continue;
+    if (/^\d/.test(t) && bookPrefix) {
+      segments.push(bookPrefix + t);
+    } else {
+      segments.push(t);
+      const m = t.match(/^([^\d]+)/);
+      if (m) bookPrefix = m[1];
+    }
+  }
+
+  const results = await Promise.all(
+    segments.map((seg) => fetchSingleRef(bibleSheetId, seg, bookNamesList, bibleDataKeys))
+  );
+  return results.filter((r): r is VerseSegment => r !== null);
+}

--- a/apps/sccny/src/messages/en.json
+++ b/apps/sccny/src/messages/en.json
@@ -323,7 +323,9 @@
       "fetchError": "Failed to fetch Bible data. Please try again later.",
       "errorTitle": "Error",
       "copyVerse": "Copy verse",
-      "copied": "Copied!"
+      "copied": "Copied!",
+      "chineseLabel": "Chinese (和合本)",
+      "englishLabel": "English (ESV)"
     },
     "liveTranslation": {
       "title": "Live Translation",

--- a/apps/sccny/src/messages/zh.json
+++ b/apps/sccny/src/messages/zh.json
@@ -323,7 +323,9 @@
       "fetchError": "获取圣经数据失败，请稍后重试。",
       "errorTitle": "错误",
       "copyVerse": "复制经文",
-      "copied": "已复制!"
+      "copied": "已复制!",
+      "chineseLabel": "中文 (和合本)",
+      "englishLabel": "英文 (ESV)"
     },
     "liveTranslation": {
       "title": "实时翻译",


### PR DESCRIPTION
## Summary

- **New `lib/bible-lookup.ts`** — server-only helper that extracts the full Bible verse lookup logic from the PPT generation tool: Chinese book abbreviation expansion (`约 → 约翰福音`), ordinal chapter normalization (`第五章 → 5`), multi-range splitting (`林前1:18-25, 2:1-8`), and binary-search key lookup against the Google Sheets Bible data (`GOOGLE_BIBLE_SHEET_ID`).
- **New `GET /api/tools/bible/sheets-search?q=<ref>`** — API endpoint that calls `lookupBibleVerses()` and returns an array of `VerseSegment` objects, each with `zhTitle`, `enTitle`, `zhVerses[]`, and `enVerses[]`.
- **Updated `/tools/bible` page** — tries the Google Sheets source first, showing Chinese and English text in a side-by-side parallel card layout. If Google Sheets is unavailable (env var not set / network error), automatically falls back to the existing external `bible.fhl.net` API with the original per-verse card layout.
- **i18n** — added `chineseLabel` / `englishLabel` keys to `en.json` and `zh.json`.

## Test plan

- [ ] Search `约 3:16` — should show parallel Chinese/English card with "约翰福音 3:16" and "John 3:16"
- [ ] Search `林前1:18-25, 2:1-8` — should return two segments (multi-range)
- [ ] Search `诗 23` — should return the full chapter (no verse specified)
- [ ] Search an invalid ref — should show "no results" empty state
- [ ] Disable `GOOGLE_BIBLE_SHEET_ID` and search — should fall back to external API silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)